### PR TITLE
Add a second slave node

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,8 @@
 
 nodes = {
   'jenkins-master' => {:ip => '172.16.11.10'},
-  'jenkins-slave'  => {:ip => '172.16.11.11'},
+  'jenkins-slave1' => {:ip => '172.16.11.11'},
+  'jenkins-slave2' => {:ip => '172.16.11.12'},
 }
 node_defaults = {
   :domain => 'internal',


### PR DESCRIPTION
This renames `jenkins-slave` to `jenkins-slave1`. You'll need to `vagrant
destroy jenkins-slave` before rolling forward to this commit. Or just remove
the existing VM from your hypervisor.

This more accurately represents the real environment that we've created.
