### PR TITLE
Namespace all hiera keys by calling class

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -5,7 +5,8 @@ classes:
 
 jenkins::lts: 1
 
-github_enterprise_cert: |
+ci_environment::jenkins_master::jenkins_servername: 'ci.alphagov.co.uk'
+ci_environment::jenkins_master::github_enterprise_cert: |
     -----BEGIN CERTIFICATE-----
     MIIEdDCCA1ygAwIBAgIJAKt4YiHj0+tVMA0GCSqGSIb3DQEBBQUAMIGCMQswCQYD
     VQQGEwJHQjEPMA0GA1UECBMGTG9uZG9uMQ8wDQYDVQQHEwZMb25kb24xFzAVBgNV
@@ -36,5 +37,3 @@ github_enterprise_cert: |
 ssl::params::ssl_path: '/etc/ssl'
 ssl::params::ssl_cert_file: 'certs/ssl-cert-snakeoil.pem'
 ssl::params::ssl_key_file: 'private/ssl-cert-snakeoil.key'
-
-ci_environment::jenkins_master::jenkins_servername: 'ci.alphagov.co.uk'

--- a/hieradata/role.ci-slave.yaml
+++ b/hieradata/role.ci-slave.yaml
@@ -1,11 +1,11 @@
 ---
-accounts:
+classes:
+    - ci_environment::jenkins_slave
+
+ci_environment::base::accounts:
     jenkins:
         home_dir: /home/jenkins
         comment: Jenkins User
-
-classes:
-    - ci_environment::jenkins_slave
 
 jenkins::slave::manage_slave_user: 0
 jenkins::slave::slave_user: jenkins

--- a/hieradata/users.yaml
+++ b/hieradata/users.yaml
@@ -1,5 +1,5 @@
 ---
-accounts:
+ci_environment::base::accounts:
     alexmuller:
         comment: Alex Muller
         ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDxuVkxqVy8kRncaG0cm/B8p7YTk7UjwE6xgUkfzIV97xAaRfNyZUI9Ur/w2x945r5IiuKGp61UHMzsGBEgmsDDNvukguY/a02yXZRySxf3ThlsqG/w7DX9uNwVEeLAA95es4P+6iApbRnBTQX7Nx/XsIa3hy8Uwr3T+pcrXCRIczhfuaiugQ/jh9IlkIC1I6UHbYoli8o5upTh9SbnimU/VXiUIO4v5z1CyLgQHfeE6VBxYO6HCQqRJg7uB4vNS5wAWyTYx4XinkS3ScjKmQr+wExyRy0vgnj5f+oVFNLgARh9lh2ViJ6ntGw8ww10b3xY/Bc/qoeFZKJjb89aMhLb

--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -1,5 +1,9 @@
 # Class applied to all CI machines
-class ci_environment::base {
+class ci_environment::base(
+  $accounts
+) {
+    validate_hash($accounts)
+
     include harden
 
     group { 'gds': ensure => present }
@@ -14,7 +18,7 @@ class ci_environment::base {
                         create_group => false,
                         groups       => ['gds']
                         }
-    create_resources( 'account', hiera_hash('accounts'), $account_defaults )
+    create_resources( 'account', $accounts, $account_defaults )
 
     exec { 'apt-get-update':
         command => '/usr/bin/apt-get update || true',

--- a/modules/ci_environment/manifests/jenkins_master.pp
+++ b/modules/ci_environment/manifests/jenkins_master.pp
@@ -1,8 +1,11 @@
 #Class to install things only on the Jenkins Master
 class ci_environment::jenkins_master (
+  $github_enterprise_cert,
   $jenkins_servername,
   $jenkins_serveraliases = []
 ) {
+    validate_string($github_enterprise_cert, $jenkins_servername)
+    validate_array($jenkins_serveraliases)
 
     Package <| title == 'jenkins' |> -> Jenkins::Plugin <| |>
 
@@ -41,7 +44,7 @@ class ci_environment::jenkins_master (
 
     file {'/etc/ssl/certs/github.gds.pem':
         ensure  => 'present',
-        content => hiera('github_enterprise_cert'),
+        content => $github_enterprise_cert,
         notify  => Exec['import-github-cert'],
     }
 


### PR DESCRIPTION
Use class params and the data binding support to neatly namespace all keys
in hiera. This makes it much clearer where they are being used and maintains
some structure in the YAML files.

None of these keys appear in ci-deployment so this change will be atomic
within this one commit.
