### PR TITLE
[#53144429] Preseed auth for slaves->master

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -9,7 +9,7 @@ mod 'torrancew/account',    '0.0.3'
 mod 'harden',   :git => 'git://github.com/alphagov/puppet-harden.git',
                 :ref => '5b27ee25e19f0c5421665246b76a13def8058e1c'
 mod 'jenkins',  :git => 'git://github.com/alphagov/puppet-jenkins.git',
-                :ref => 'bdedadec4beb67b1623c9e7851904039cd60d473'
+                :ref => '938d94694f8a5d90061dc246aaacf3a57ce2f027'
 mod 'nginx',    :git => 'git://github.com/alphagov/puppet-nginx.git',
                 :ref => '1a87dd9fb29f5f137e3d4ee42ddcf45c9054700e'
 mod 'ssl',      :git => 'git://github.com/alphagov/puppet-ssl.git',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: git://github.com/alphagov/puppet-jenkins.git
-  ref: bdedadec4beb67b1623c9e7851904039cd60d473
-  sha: bdedadec4beb67b1623c9e7851904039cd60d473
+  ref: 938d94694f8a5d90061dc246aaacf3a57ce2f027
+  sha: 938d94694f8a5d90061dc246aaacf3a57ce2f027
   specs:
     jenkins (0.2.4)
       puppetlabs/apt (>= 0.0.3)

--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -6,5 +6,9 @@ gds_dns::server::hosts: |
     172.16.11.11 ci-slave-1 slave
     172.16.11.12 ci-slave-2 slave
 
+ci_environment::jenkins_master::slave_token_hash: 'ANCpjrHadvgO23ft6jsYLa5WF8yy0jAxcOW6ml5ovra04Jm0a23kZN4imGoifBDU'
 ci_environment::jenkins_master::jenkins_serveraliases:
   - '172.16.11.10'
+
+jenkins::slave::ui_user: 'slave'
+jenkins::slave::ui_pass: '28a803802d865bd1472b1d8309ac4d12'

--- a/modules/ci_environment/manifests/jenkins_master.pp
+++ b/modules/ci_environment/manifests/jenkins_master.pp
@@ -2,7 +2,9 @@
 class ci_environment::jenkins_master (
   $github_enterprise_cert,
   $jenkins_servername,
-  $jenkins_serveraliases = []
+  $jenkins_serveraliases = [],
+  $slave_user = 'slave',
+  $slave_token_hash
 ) {
     validate_string($github_enterprise_cert, $jenkins_servername)
     validate_array($jenkins_serveraliases)
@@ -56,5 +58,9 @@ class ci_environment::jenkins_master (
         unless  => '/usr/bin/keytool -list \
                     -keystore /etc/ssl/certs/java/cacerts \
                     -storepass changeit | grep github.gds',
+    }
+
+    jenkins::api_user { $slave_user:
+      token_hash => $slave_token_hash,
     }
 }


### PR DESCRIPTION
Use a new defined type from alphagov/puppet-jenkins#1 to create a local
Jenkins user account with a preset API token. This is decoupled from
LDAP/oAuth (as all API tokens are), so it will work out-of-the-box.

Created some new credentials for use in Vagrant. It doesn't matter that
these are public. Production credentials will be generated and committed to
gds/ci-deployment, separately.
