### PR TITLE
[#53144429] Don't preset hashed API token

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -9,7 +9,7 @@ mod 'torrancew/account',    '0.0.3'
 mod 'harden',   :git => 'git://github.com/alphagov/puppet-harden.git',
                 :ref => '5b27ee25e19f0c5421665246b76a13def8058e1c'
 mod 'jenkins',  :git => 'git://github.com/alphagov/puppet-jenkins.git',
-                :ref => 'dcec04d914a7de0daa1faf66e01e7985e24a79ad'
+                :ref => 'f7a85ae0ac1293f5f0e64dc86114a265299cc23f'
 mod 'nginx',    :git => 'git://github.com/alphagov/puppet-nginx.git',
                 :ref => '1a87dd9fb29f5f137e3d4ee42ddcf45c9054700e'
 mod 'ssl',      :git => 'git://github.com/alphagov/puppet-ssl.git',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: git://github.com/alphagov/puppet-jenkins.git
-  ref: dcec04d914a7de0daa1faf66e01e7985e24a79ad
-  sha: dcec04d914a7de0daa1faf66e01e7985e24a79ad
+  ref: f7a85ae0ac1293f5f0e64dc86114a265299cc23f
+  sha: f7a85ae0ac1293f5f0e64dc86114a265299cc23f
   specs:
     jenkins (0.2.4)
       puppetlabs/apt (>= 0.0.3)

--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -6,9 +6,9 @@ gds_dns::server::hosts: |
     172.16.11.11 ci-slave-1 slave
     172.16.11.12 ci-slave-2 slave
 
-ci_environment::jenkins_master::slave_token_hash: 'ANCpjrHadvgO23ft6jsYLa5WF8yy0jAxcOW6ml5ovra04Jm0a23kZN4imGoifBDU'
 ci_environment::jenkins_master::jenkins_serveraliases:
   - '172.16.11.10'
 
+# The token will need to be reset after each master install.
 jenkins::slave::ui_user: 'slave'
-jenkins::slave::ui_pass: '28a803802d865bd1472b1d8309ac4d12'
+jenkins::slave::ui_pass: 'REDACTED'

--- a/modules/ci_environment/manifests/jenkins_master.pp
+++ b/modules/ci_environment/manifests/jenkins_master.pp
@@ -1,10 +1,16 @@
-#Class to install things only on the Jenkins Master
+# == Class: ci_environment::jenkins_master
+#
+# Class to install things only on the Jenkins Master
+#
+# See opsmanual for manual steps:
+#
+#   https://github.gds/pages/gds/opsmanual/infrastructure/howto/configuring-ci-environment-and-machines.html
+#
 class ci_environment::jenkins_master (
   $github_enterprise_cert,
   $jenkins_servername,
   $jenkins_serveraliases = [],
-  $slave_user = 'slave',
-  $slave_token_hash
+  $slave_user = 'slave'
 ) {
     validate_string($github_enterprise_cert, $jenkins_servername)
     validate_array($jenkins_serveraliases)
@@ -60,7 +66,5 @@ class ci_environment::jenkins_master (
                     -storepass changeit | grep github.gds',
     }
 
-    jenkins::api_user { $slave_user:
-      token_hash => $slave_token_hash,
-    }
+    jenkins::api_user { $slave_user: }
 }

--- a/modules/ci_environment/manifests/jenkins_slave.pp
+++ b/modules/ci_environment/manifests/jenkins_slave.pp
@@ -1,4 +1,9 @@
-#Class to install things only on the Jenkins Slave
+# == Class: ci_environment::jenkins_slave
+#
+# Class to install things only on the Jenkins Slave
+#
+# API token in hiera needs to be updated after provisioning a new master.
+#
 class ci_environment::jenkins_slave {
     include java
     include jenkins::slave


### PR DESCRIPTION
A user's API token is hashed against a seed that is particular to a given
installation of Jenkins. So we can't reliably preset it. Full details in:

alphagov/puppet-jenkins@02e1edcb8dd4a3ac822f7f12b3bbe250cdb931a7

You will need to update hierdata (but not commit it) with the correct
`ui_pass` each time you create a `ci-master-1` node in Vagrant. For real
environments this should stay relatively static.

/cc @danielabel 
