### PR TITLE
Fixed issue of accounts not getting added to ci slaves

### DIFF
--- a/hieradata/role.ci-slave.yaml
+++ b/hieradata/role.ci-slave.yaml
@@ -2,7 +2,7 @@
 classes:
  - ci_environment::jenkins_slave
 
-ci_environment::base::accounts:
+ci_environment::jenkins_slave::accounts:
     jenkins:
         home_dir: /home/jenkins
         comment: Jenkins User

--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -18,7 +18,7 @@ class ci_environment::base(
                         create_group => false,
                         groups       => ['gds']
                         }
-    create_resources( 'account', $accounts, $account_defaults )
+    create_resources('account', $accounts, $account_defaults )
 
     exec { 'apt-get-update':
         command => '/usr/bin/apt-get update || true',

--- a/modules/ci_environment/manifests/jenkins_slave.pp
+++ b/modules/ci_environment/manifests/jenkins_slave.pp
@@ -4,9 +4,15 @@
 #
 # API token in hiera needs to be updated after provisioning a new master.
 #
-class ci_environment::jenkins_slave {
+class ci_environment::jenkins_slave(
+  $accounts
+) {
+    validate_hash($accounts)
+
     include java
     include jenkins::slave
+
+    create_resources('account', $accounts)
 
     Exec['apt-get-update'] -> Class['java'] -> Class['jenkins::slave']
 }


### PR DESCRIPTION
`ci_environment::base::accounts` in `users.yaml`  was been overriden in
`role.ci-slave.yaml`, because of which user accounts where not been
created in ci-slaves
