### PR TITLE
[#54023271] adding a machine user for pingdom health checks

### DIFF
--- a/modules/ci_environment/manifests/jenkins_master.pp
+++ b/modules/ci_environment/manifests/jenkins_master.pp
@@ -68,4 +68,5 @@ class ci_environment::jenkins_master (
     }
 
     jenkins::api_user { $slave_user: }
+    jenkins::api_user { 'pingdom': }
 }


### PR DESCRIPTION
The only automation we can do here it set up a machine user, there is manual work documented in the ops manual as to how to use this user to set up the checks

/cc @samjsharpe 
