### PR TITLE
Extract accounts logic to a wrapper module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -4,7 +4,6 @@ mod 'gdsoperations/openconnect', '0.0.5'
 mod 'puppetlabs/java',           '0.3.0'
 mod 'puppetlabs/stdlib',         '~> 3.0'
 mod 'saz/dnsmasq',               '1.0.1'
-mod 'torrancew/account',         '0.0.3'
 mod 'pdxcat/collectd',           '~> 0.0'
 mod 'attachmentgenie/ufw',       '1.1.0'
 mod 'attachmentgenie/ssh',       '1.1.1'
@@ -20,5 +19,7 @@ mod 'nginx',        :git => 'git://github.com/alphagov/puppet-nginx.git',
                     :ref => '1a87dd9fb29f5f137e3d4ee42ddcf45c9054700e'
 mod 'ssl',          :git => 'git://github.com/alphagov/puppet-ssl.git',
                     :ref => '23bbb5ab57f26269acce3d4b43e643781747a551'
+mod 'gds_accounts', :git => 'git://github.com/alphagov/puppet-gds_accounts.git',
+                    :ref => 'v0.0.1'
 mod 'gds/graphite', :git => 'git://github.com/gds-operations/puppet-graphite.git',
                     :ref => '45663a5cd8ed72d7cb8d19e535136cacd893689d'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -3,6 +3,7 @@ FORGE
   specs:
     puppetlabs/apt (1.2.0)
       puppetlabs/stdlib (>= 2.2.1)
+    torrancew/account (0.0.5)
 
 FORGE
   remote: http://forge.puppetlabs.com/
@@ -20,7 +21,15 @@ FORGE
       puppetlabs/stdlib (>= 0.1.6)
     puppetlabs/stdlib (3.2.0)
     saz/dnsmasq (1.0.1)
-    torrancew/account (0.0.3)
+
+GIT
+  remote: git://github.com/alphagov/puppet-gds_accounts.git
+  ref: v0.0.1
+  sha: 3698859f788f95a866f2f7e0fa3cad9bcfa129b5
+  specs:
+    gds_accounts (0.0.1)
+      puppetlabs/stdlib (>= 3.0.0)
+      torrancew/account (= 0.0.5)
 
 GIT
   remote: git://github.com/alphagov/puppet-harden.git
@@ -72,6 +81,7 @@ DEPENDENCIES
   attachmentgenie/ufw (= 1.1.0)
   fail2ban (>= 0)
   gds/graphite (>= 0)
+  gds_accounts (>= 0)
   gdsoperations/openconnect (= 0.0.5)
   harden (>= 0)
   jenkins (>= 0)
@@ -82,5 +92,4 @@ DEPENDENCIES
   puppetlabs/stdlib (~> 3.0)
   saz/dnsmasq (= 1.0.1)
   ssl (>= 0)
-  torrancew/account (= 0.0.3)
 

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -3,6 +3,7 @@ classes:
   - ci_environment::base
   - ci_environment::dns
   - gds_collectd
+  - gds_accounts
   - ci_environment::firewall_config::base
 
 jenkins::lts: 1

--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -1,6 +1,10 @@
 ---
 jenkins::slave::broadcast_address: 172.16.11.255
 
+gds_accounts::purge_ignore:
+  - 'vagrant'
+  - 'vboxadd'
+
 gds_dns::server::hosts: |
     172.16.11.10 ci-master-1 master
     172.16.11.11 ci-slave-1 slave

--- a/hieradata/users.yaml
+++ b/hieradata/users.yaml
@@ -1,5 +1,5 @@
 ---
-ci_environment::base::accounts:
+gds_accounts::accounts:
     alexmuller:
         comment: Alex Muller
         ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDxuVkxqVy8kRncaG0cm/B8p7YTk7UjwE6xgUkfzIV97xAaRfNyZUI9Ur/w2x945r5IiuKGp61UHMzsGBEgmsDDNvukguY/a02yXZRySxf3ThlsqG/w7DX9uNwVEeLAA95es4P+6iApbRnBTQX7Nx/XsIa3hy8Uwr3T+pcrXCRIczhfuaiugQ/jh9IlkIC1I6UHbYoli8o5upTh9SbnimU/VXiUIO4v5z1CyLgQHfeE6VBxYO6HCQqRJg7uB4vNS5wAWyTYx4XinkS3ScjKmQr+wExyRy0vgnj5f+oVFNLgARh9lh2ViJ6ntGw8ww10b3xY/Bc/qoeFZKJjb89aMhLb

--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -2,27 +2,16 @@
 #
 # Class applied to all CI machines
 #
-class ci_environment::base(
-  $accounts
-) {
-  validate_hash($accounts)
-
+class ci_environment::base {
   include harden
   include github_sshkeys
 
-  group { 'gds': ensure => present }
   file { '/etc/sudoers.d/gds':
     ensure  => present,
     mode    => '0440',
     content => '%gds ALL=(ALL) NOPASSWD: ALL
 '
   }
-  $account_defaults = {
-                      require      => Group['gds'],
-                      create_group => false,
-                      groups       => ['gds']
-                      }
-  create_resources('account', $accounts, $account_defaults)
 
   class { 'fail2ban':
     require => Exec['apt-get-update']


### PR DESCRIPTION
In order to re-use the same functionality for the Mirror project. Mostly
cribbed from the code here. Only functional difference is that it will purge
unmanaged non-system accounts. The `vagrant` and `vboxadd` users have been
excluded in the development environment, accordingly.
