### PR TITLE
[#53062579] Support jobs to be triggered from Github

### DIFF
--- a/modules/ci_environment/manifests/jenkins_master.pp
+++ b/modules/ci_environment/manifests/jenkins_master.pp
@@ -75,6 +75,7 @@ class ci_environment::jenkins_master (
 
   jenkins::api_user { $slave_user: }
   jenkins::api_user { 'pingdom': }
+  jenkins::api_user { 'github_build_trigger': }
 
   file { "${jenkins_home}/hudson.plugins.warnings.WarningsPublisher.xml":
     ensure => 'present',


### PR DESCRIPTION
There is little work in being able to trigger jobs from Hithub, via heroku we do need a user to allow us to securely 
connect
- added user to be used in triggered jobs from github

/cc @dcarley @singhgarima 
