### PR TITLE
Add locales module so that puppet manages locales

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -11,6 +11,7 @@ mod 'attachmentgenie/ssh',         '1.1.1'
 mod 'puppetlabs/git',              '0.0.2'
 mod 'puppetlabs/mysql',            '0.9.0'
 mod 'gdsoperations/elasticsearch', '0.0.1'
+mod 'attachmentgenie/locales',     '1.0.2'
 
 mod 'fail2ban',     :git => 'git://github.com/valentinroca/puppet-fail2ban',
                     :ref => '201ac7d0f30a118234a7f2edf4be4bd5c99954ce'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -8,6 +8,8 @@ FORGE
 FORGE
   remote: http://forge.puppetlabs.com/
   specs:
+    attachmentgenie/locales (1.0.2)
+      puppetlabs/stdlib (>= 2.2.1)
     attachmentgenie/ssh (1.1.1)
       puppetlabs/stdlib (>= 2.2.1)
     attachmentgenie/ufw (1.1.0)
@@ -90,6 +92,7 @@ GIT
     fail2ban (1.1.0)
 
 DEPENDENCIES
+  attachmentgenie/locales (= 1.0.2)
   attachmentgenie/ssh (= 1.1.1)
   attachmentgenie/ufw (= 1.1.0)
   fail2ban (>= 0)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -5,8 +5,13 @@ classes:
   - gds_collectd
   - gds_accounts
   - ci_environment::firewall_config::base
+  - locales
 
 jenkins::lts: 1
+
+locales::default_value: en_GB.UTF-8
+locales::available:
+  - "en_GB.UTF-8 UTF-8"
 
 ci_environment::github_sshkeys::github_dotcom_key: 'AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
 


### PR DESCRIPTION
At the moment, the default locale is at the whim of the base image that's used, and is currently different between vagrant and the deployed instances.  This will enforce uniformity.
