### PR TITLE
Require python-pip for ghtools

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -39,6 +39,7 @@ class ci_environment::jenkins_job_support {
   package { 'ghtools':
     ensure   => '0.21.0',
     provider => pip,
+    require  => Package['python-pip'],
   }
 
   package { 'brakeman':


### PR DESCRIPTION
This doesn't feel quite like the correct solution (surely setting `provider => pip` should make sure pip is available?), but it works.

```
Error: Could not update: Could not locate the pip command.
Error: /Stage[main]/Ci_environment::Jenkins_job_support/Package[ghtools]/ensure: change from absent to 0.21.0 failed: Could not update: Could not locate the pip command.
```
