### PR TITLE
Use nodeenv to install Node.js dependencies

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -100,13 +100,14 @@ class ci_environment::jenkins_job_support {
   }
 
   # uglifier requires a JavaScript runtime
-  # alphagov/spotlight requires a decent version of Node (0.10+) and grunt-cli
+  # alphagov/spotlight requires a decent version of Node (0.10+)
+  # We install dependencies using nodeenv
   package { 'nodejs':
     ensure => "0.10.20-1chl1~${::lsbdistcodename}1",
   }
-  package { 'grunt-cli':
-    ensure   => '0.1.9',
-    provider => 'npm',
+  package { 'nodeenv':
+    ensure   => '0.7.0',
+    provider => 'pip',
     require  => Package['nodejs'],
   }
 }


### PR DESCRIPTION
We should probably keep the global Node.js install there for uglifier. We've just made it shiny and updated it. [nodeenv](https://github.com/ekalinin/nodeenv) installs Node.js itself.
