### PR TITLE
Create restricted SSH users to transfer logs

### DIFF
--- a/hieradata/role.transition-logs.yaml
+++ b/hieradata/role.transition-logs.yaml
@@ -4,3 +4,8 @@ classes:
  - ci_environment::transition_logs
  - ci_environment::firewall_config::transition_logs
 
+ci_environment::transition_logs::rssh_users:
+    mhra:
+        comment: MHRA
+        ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAAAgQDLxOkttJUcivHvVqWCsmLMvuyXtXe2mTceIh84mA05uwlVtPjdIC4bupl3yncswxnc6A6aJZk35FA8NCxod55eVicM1+sTgnQEIEDr7UxXFyvd89f0lOilojUuC4Mkt9Lun8wDRu1rW1i9chVoZQL5masYzJzku4DuK9e9DyJBGw==
+        home_dir: /srv/logs/log-1/mhra

--- a/modules/ci_environment/manifests/transition_logs.pp
+++ b/modules/ci_environment/manifests/transition_logs.pp
@@ -3,4 +3,30 @@
 # Class to install things only on the Transition Logs
 #
 class ci_environment::transition_logs {
+    $accounts = hiera('ci_environment::transition_logs::rssh_users')
+
+    package{'rssh':
+        ensure => present,
+    }
+
+    create_resources('account', $accounts, {
+        shell          => '/usr/bin/rssh',
+        require        => File['/srv/logs/log-1'],
+        })
+
+    file {'/etc/rssh.conf':
+        ensure  => present,
+        content => template('ci_environment/etc/rssh.conf.erb'),
+    }
+
+    file {['/srv/logs','/srv/logs/log-1']:
+        ensure => directory,
+    }
+
+    file {'/usr/lib/rssh/rssh_chroot_helper':
+        ensure => present,
+        mode   => '4775',
+    }
+
+    Exec['apt-get-update'] -> Package['rssh'] -> File['/etc/rssh.conf'] -> File['/usr/lib/rssh/rssh_chroot_helper']
 }

--- a/modules/ci_environment/templates/etc/rssh.conf.erb
+++ b/modules/ci_environment/templates/etc/rssh.conf.erb
@@ -1,0 +1,6 @@
+# set the log facility.  "LOG_USER" and "user" are equivalent.
+logfacility = LOG_USER
+<% @accounts.each do |user,details| -%>
+#user=<%= user %>:077:000110:<%= details['home_dir'] %> #chroot doesn't seem to work
+user=<%= user %>:077:000110:
+<% end -%>


### PR DESCRIPTION
This creates users on the transition logs machines.

The users are 'special' in that their shell is `/usr/bin/rssh` which is configured to only allow them to use `scp` and `sftp`.
