### PR TITLE
Revert "Use nodeenv to install our dependencies"

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -100,14 +100,13 @@ class ci_environment::jenkins_job_support {
   }
 
   # uglifier requires a JavaScript runtime
-  # alphagov/spotlight requires a decent version of Node (0.10+)
-  # We install dependencies using nodeenv
+  # alphagov/spotlight requires a decent version of Node (0.10+) and grunt-cli
   package { 'nodejs':
     ensure => "0.10.20-1chl1~${::lsbdistcodename}1",
   }
-  package { 'nodeenv':
-    ensure   => '0.7.0',
-    provider => 'pip',
+  package { 'grunt-cli':
+    ensure   => '0.1.9',
+    provider => 'npm',
     require  => Package['nodejs'],
   }
 }


### PR DESCRIPTION
This reverts commit d7a5045c55d9f7318e19ad90bd29530640cb236b.

We're using the global Node.js version until someone tells us
they want to use a different version.
