### PR TITLE
Update Node.js

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -102,7 +102,7 @@ class ci_environment::jenkins_job_support {
   # uglifier requires a JavaScript runtime
   # alphagov/spotlight requires a decent version of Node (0.10+) and grunt-cli
   package { 'nodejs':
-    ensure => "0.10.20-1chl1~${::lsbdistcodename}1",
+    ensure => "0.10.21-1chl1~${::lsbdistcodename}1",
   }
   package { 'grunt-cli':
     ensure   => '0.1.9',


### PR DESCRIPTION
0.10.21 has been added to the CI PPA.

I'm hoping `apt-get update` [will have run already](https://github.com/alphagov/ci-puppet/blob/1604a583b9fa35d6914abb4a126c4d791a45eb75/modules/ci_environment/manifests/base.pp#L70).

See also: https://github.com/alphagov/pp-puppet/pull/81
