### PR TITLE
Add libv8 dev

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -33,6 +33,7 @@ class ci_environment::jenkins_job_support {
     'aspell', 'aspell-en', 'libaspell-dev', # Needed by rummager
     'libqtwebkit-dev', # Needed by capybara-webkit (Publisher)
     'bzr', # needed by some Go builds
+    'libv8-dev', # Needed by things that require V8 headers
   ])
 
   package { 'golang':


### PR DESCRIPTION
Without this package things that need `.h` files from libv8 [won't compile](https://github.com/alphagov/static/commit/0976e56ae9b00c58705270eaa809e1be16fe77df).
