### PR TITLE
[#60058920] Install Vegeta for Router

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -34,6 +34,7 @@ class ci_environment::jenkins_job_support {
     'libqtwebkit-dev', # Needed by capybara-webkit (Publisher)
     'bzr', # needed by some Go builds
     'libv8-dev', # Needed by things that require V8 headers
+    'vegeta', # HTTP load testing used by Router.
   ])
 
   package { 'golang':


### PR DESCRIPTION
[Vegeta](https://github.com/tsenart/vegeta) is an HTTP load testing tool
used by the Router to test for performance regressions. It has been added to
the GOV.UK PPA here:
- https://github.com/alphagov/packager/pull/13
- https://launchpad.net/~gds/+archive/govuk/+sourcepub/3643228/+listing-archive-extra
