### PR TITLE
Add PHP for redirector

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -35,6 +35,7 @@ class ci_environment::jenkins_job_support {
     'bzr', # needed by some Go builds
     'libv8-dev', # Needed by things that require V8 headers
     'vegeta', # HTTP load testing used by Router.
+    'php5-cli', # Needed by redirector
   ])
 
   package { 'golang':


### PR DESCRIPTION
As far as we can tell, redirector CI build needs the PHP command line client but not the server.

I've based this on the GOV.UK puppet PHP module: https://github.gds/gds/puppet/blob/master/modules/php/manifests/init.pp#L10-L12
