### PR TITLE
[#60949022] Move Fail2Ban config to its own class

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -6,6 +6,7 @@ class ci_environment::base {
   apt::ppa { 'ppa:gds/govuk': }
   apt::ppa { 'ppa:gds/ci': }
 
+  include ci_environment::fail2ban
   include harden
   include github_sshkeys
   include rbenv
@@ -66,18 +67,6 @@ class ci_environment::base {
   file { '/etc/ssh/ssh_known_hosts':
     ensure  => present,
     mode    => '0644',
-  }
-
-  class { 'fail2ban':
-    require => Exec['apt-get-update']
-  }
-
-  file { '/etc/fail2ban/jail.local':
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    source  => 'puppet:///modules/ci_environment/jail.local',
-    require => Class['fail2ban'],
   }
 
   include ssh::server

--- a/modules/ci_environment/manifests/fail2ban.pp
+++ b/modules/ci_environment/manifests/fail2ban.pp
@@ -1,0 +1,22 @@
+# == Class: ci_environment::fail2ban
+#
+# Installs fail2ban for IP blacklisting
+#
+class ci_environment::fail2ban {
+  $whitelist_ips = hiera('ci_environment::fail2ban::whitelist_ips')
+
+  class { '::fail2ban':
+    require => Exec['apt-get-update']
+  }
+
+  file { '/etc/fail2ban/jail.local':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => template('ci_environment/etc/fail2ban/jail.local.erb'),
+    notify  => Service['fail2ban'],
+    # Require package rather than class to avoid dependency issues
+    # incurred by the Fail2Ban module we are using.
+    require => Package['fail2ban'],
+  }
+}

--- a/modules/ci_environment/templates/etc/fail2ban/jail.local.erb
+++ b/modules/ci_environment/templates/etc/fail2ban/jail.local.erb
@@ -5,5 +5,4 @@
 # "ignoreip" can be an IP address, a CIDR mask or a DNS host. Fail2ban
 # will not ban a host which matches an address in this list. Several
 # addresses can be defined using space separator.
-# IPs starting 80.194.x.x are for Aviation House
-ignoreip = 127.0.0.1 80.194.77.90 80.194.77.100
+ignoreip = <%= whitelist_ips.join(" ") %>


### PR DESCRIPTION
- Move Fail2Ban configuration to its own class to avoid polluting the
  ci_environment base.pp manifest.
- Replace hardcoded IPs to be whitelisted by Fail2Ban with a hiera
  array.
- Notify Fail2Ban service when jail.local file is updated.
