### PR TITLE
Provide default for fail2ban whitelist

### DIFF
--- a/modules/ci_environment/manifests/fail2ban.pp
+++ b/modules/ci_environment/manifests/fail2ban.pp
@@ -2,9 +2,9 @@
 #
 # Installs fail2ban for IP blacklisting
 #
-class ci_environment::fail2ban {
-  $whitelist_ips = hiera('ci_environment::fail2ban::whitelist_ips')
-
+class ci_environment::fail2ban(
+  $whitelist_ips = ['127.0.0.1'],
+) {
   class { '::fail2ban':
     require => Exec['apt-get-update']
   }


### PR DESCRIPTION
Allows this class to be used in Vagrant -- without `env.production.yaml` in
the deployment repo. Otherwise the following happens:

```
Error: Could not find data item ci_environment::fail2ban::whitelist_ips in any Hiera data file and no default supplied at /tmp/vagrant-puppet/modules-0/ci_environment/manifests/fail
2ban.pp:6 on node transition-logs-1
```

Also changes the explicit `hiera()` call to a class param, which is more
standard and easier to use.
