### PR TITLE
[#59323898] Remove formatting for CDN logs

### DIFF
--- a/modules/cdn_logs/templates/etc/rsyslog.d/10-cdn_remote.conf.erb
+++ b/modules/cdn_logs/templates/etc/rsyslog.d/10-cdn_remote.conf.erb
@@ -19,8 +19,11 @@ $RepeatedMsgReduction off
 # Switch to remote ruleset
 $RuleSet cdn
 
+# Record raw message content without leading space.
+$template NoFormat,"%msg:2:$:%\n"
+
 # Log everything from this source.
-*.* -<%= @log_dir -%>/bouncer_and_redirector.log
+*.* -<%= @log_dir -%>/bouncer_and_redirector.log;NoFormat
 
 # Switch back to default ruleset
 $RuleSet RSYSLOG_DefaultRuleset


### PR DESCRIPTION
Record CDN access logs without any additional syslog formatting/info. The
`:2:$:` formatter prints everything after the first character, in order to
remove syslog's default preceding space.

We've opted not to use Sam's snippet for prefixing the log line with a
formatted `%timestamp%`/`%timereported%` because discrepencies between the
syslog time and `%t` generated by the CDN make us nervous that it isn't
accurate enough.

Instead we'll put up with their format and quote it, so that it's easier to
pass. We're also omitting a lot of information that the Transition team
don't need and would be sensitive for privacy reasons. Resulting in a final
formatting config of:

```
req.http.host "%t" "%r" %>s %b
```

---

/cc @jamiecobbett @jennyd 
