### PR TITLE
[#59323898] Daily rotate and dateext for CDN logs

### DIFF
--- a/modules/cdn_logs/templates/etc/logrotate.d/cdn_logs.erb
+++ b/modules/cdn_logs/templates/etc/logrotate.d/cdn_logs.erb
@@ -1,7 +1,8 @@
 <%= log_dir -%>/*.log
 {
-  rotate 12
-  monthly
+  rotate 365
+  daily
+  dateext
   compress
   delaycompress
   missingok


### PR DESCRIPTION
Rotate the CDN logs daily, rather than monthly, because they are expected to
grow fast and it matches the rate that the Transition team are expecting to
consume them. The retention period of one year remains the same.

Also append a date to each log when it's rotated. Rather than a rotating
integer, so that it's easy to see what period each log relates to.

---

/cc @rjw1 @jamiecobbett @jennyd 
