### PR TITLE
[#59323898] Move CDN logs to separate mount

### DIFF
--- a/modules/cdn_logs/manifests/init.pp
+++ b/modules/cdn_logs/manifests/init.pp
@@ -8,7 +8,7 @@ class cdn_logs (
   $key_file = '/etc/ssl/rsyslog.key',
   $cert,
   $cert_file = '/etc/ssl/rsyslog.crt',
-  $log_dir = '/srv/logs/cdn',
+  $log_dir = '/srv/logs/log-1/cdn',
 ) {
   file { $log_dir:
     ensure => directory,


### PR DESCRIPTION
The existing path belongs to the root partition, which isn't very big. Move
it to `/srv/logs/log-1` which is created by `ci_environment::transition_logs`
and lives on a separate partition:

```
dcarley@transition-logs-1:~$ df -h / /srv/logs/log-1/
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda2       9.4G  2.7G  6.3G  31% /
/dev/sdb1       252G   54G  199G  22% /srv/logs/log-1
```

The old dir/log should be deleted after deploying.

---

/cc @rjw1 @jamiecobbett @jennyd 
