### PR TITLE
Install mawk-1.3.4 on transition-logs-1

### DIFF
--- a/modules/ci_environment/manifests/transition_logs.pp
+++ b/modules/ci_environment/manifests/transition_logs.pp
@@ -5,9 +5,11 @@
 class ci_environment::transition_logs {
     $accounts = hiera('ci_environment::transition_logs::rssh_users')
 
-    package{'rssh':
-        ensure => present,
-    }
+    ensure_packages([
+        'rssh',
+        # Provides /opt/mawk required by pre-transition-stats for processing logs
+        'mawk-1.3.4',
+    ])
 
     create_resources('account', $accounts, {
         shell          => '/usr/bin/rssh',


### PR DESCRIPTION
As well as needing this version of mawk for Jenkins jobs, we also
need it on transition-logs-1 for actually doing the processing of
the logfiles, which are uploaded onto there.
