### PR TITLE
Increase rsyslog max line length

### DIFF
--- a/modules/cdn_logs/templates/etc/rsyslog.d/10-cdn_remote.conf.erb
+++ b/modules/cdn_logs/templates/etc/rsyslog.d/10-cdn_remote.conf.erb
@@ -33,3 +33,6 @@ $InputTCPServerRun <%= @port %>
 
 # Restore message de-dupe.
 $RepeatedMsgReduction on
+
+# Use the same max-line-length as Fastly
+$MaxMessageSize 16k


### PR DESCRIPTION
Fastly's max line length is 16k, the default rsyslog is 2k, so we are inserting a line break at 2k.

This is a problem for several lines per day when we try to process the logs with awk.

I used this as my reference: http://www.rsyslog.com/doc/rsyslog_conf_global.html I'm unsure how to test, but I can deploy and monitor it. If it were to break somehow, we have another copy of the logs going to another server for the time being.

Perhaps relevant:
Fastly say that they truncate at 16k rather than insert a line break.

/cc @dcarley 
