### PR TITLE
rbenv and bundler for logs processor

### DIFF
--- a/modules/ci_environment/files/process_transition_logs.sh
+++ b/modules/ci_environment/files/process_transition_logs.sh
@@ -16,6 +16,11 @@ else
     exit 1
 fi
 
+BUNDLE_DIR='/srv/logs/log-1/logs_processor/bundle'
+if [ ! -d "$BUNDLE_DIR" ]; then
+    mkdir "$BUNDLE_DIR"
+fi
+
 # clone repos
 for REPO in transition-stats pre-transition-stats
 do
@@ -47,7 +52,7 @@ cd ..
 LOGS_DIR='/srv/logs/log-1/cdn'
 
 (cd pre-transition-stats &&
-    bundle install &&
+    bundle install --path "$BUNDLE_DIR" &&
     bundle exec bin/hits update "$LOGS_DIR" --output-dir '../transition-stats/hits')
 
 # move into transition-stats, which should already be on the right branch, to


### PR DESCRIPTION
- source `/etc/profile.d/rbenv.sh` so that the logs_processor user can use Bundler and the right Ruby version
- `bundle install` within the user's home directory, rather than trying to install gems globally
