### PR TITLE
Updates mongo to the same version used by performance platform

### DIFF
--- a/hieradata/role.ci-slave.2.yaml
+++ b/hieradata/role.ci-slave.2.yaml
@@ -2,7 +2,7 @@
 classes:
  - rabbitmq
 
-jenkins::slave::labels: '"mongodb-2.4.9 rabbitmq java6"'
+jenkins::slave::labels: '"mongodb-2.4 rabbitmq java6"'
 
 mongodb::version: 2.4.9
 java::package: 'openjdk-6-jdk'

--- a/hieradata/role.ci-slave.4.yaml
+++ b/hieradata/role.ci-slave.4.yaml
@@ -1,4 +1,4 @@
 ---
-jenkins::slave::labels: 'mongodb-2.4.9'
+jenkins::slave::labels: 'mongodb-2.4'
 
 mongodb::version: 2.4.9


### PR DESCRIPTION
- This fixes a bug for us which is causing tests to fail:
  https://ci-new.alphagov.co.uk/job/performanceplatform_backdrop/1115/console
- Details of the bug in versions 2.4.3-6 are here https://jira.mongodb.org/browse/SERVER-9501
