### PR TITLE
Revert "Set up rbenv in logs processing script"

### DIFF
--- a/modules/ci_environment/files/process_transition_logs.sh
+++ b/modules/ci_environment/files/process_transition_logs.sh
@@ -7,15 +7,6 @@
 
 set -e
 
-# Set up rbenv for the logs_processor user, which is necessary because it
-# doesn't have a proper login shell
-if [ -f /etc/profile.d/rbenv.sh ]; then
-    source /etc/profile.d/rbenv.sh
-else
-    echo "Can't setup rbenv, so processing will fail"
-    exit 1
-fi
-
 BUNDLE_DIR='/srv/logs/log-1/logs_processor/bundle'
 if [ ! -d "$BUNDLE_DIR" ]; then
     mkdir "$BUNDLE_DIR"


### PR DESCRIPTION
This reverts commit 40a4dfc6b7b2f35bc6c1866635b7ff8c257c2585.

We did this in an attempt to make the logs_processor able to run
this script from a cron job, which otherwise would not set up the
environment correctly for rbenv. However, the script exits immediately
after sourcing rbenv.sh, probably because `rbenv rehash` exits with 1
with the error 'rbenv: cannot rehash: /usr/lib/rbenv/shims/.rbenv-shim exists'
even though it doesn't. Since we don't need this in here right now,
it's better to remove it. Becoming the logs_processor user with
'sudo su - logs_processor' sets up the environment including rbenv
so this script can be run successfully.
