### PR TITLE
Pin jenkins version to work around issue with new version

### DIFF
--- a/hieradata/role.ci-master.yaml
+++ b/hieradata/role.ci-master.yaml
@@ -7,7 +7,7 @@ classes:
 ci_environment::jenkins_user::jenkins_home: /var/lib/jenkins
 ci_environment::jenkins_master::jenkins_home: /var/lib/jenkins
 
-jenkins::version: latest
+jenkins::version: "1.532.1"
 jenkins::plugin_hash:
     greenballs:
         version: "1.12"


### PR DESCRIPTION
1.532.2 Caused swarm clients to be unable to authenticate.  Pin the version to the previous one until we've got to the bottom of this.
