### PR TITLE
Fix colon in quoted YAML comment

### DIFF
--- a/hieradata/role.transition-logs.yaml
+++ b/hieradata/role.transition-logs.yaml
@@ -113,6 +113,6 @@ ci_environment::transition_logs::rssh_users:
         home_dir: /srv/logs/log-1/defra
 
     defra_darwin:
-        comment: "Defra: Darwin Initiative"
+        comment: "Defra - Darwin Initiative"
         ssh_key: AAAAB3NzaC1yc2EAAAABIwAAAQEA162Kr65miLEcUnCr0kM6B2VDqxRzKJTv9OSKgYBT75KGLUngzkdWMkKhYgtEoeMT2dvHB712Q8s6E5mkyuWRFDwOiMioO/Vk8QfdL7a/gY0brtP7WQN/fQvDE2lflxCdGZ2x0zeTcC3xLbAiYX1TtiRUjIE/rBhQhpxDI1FxhKIM+9f5G7t71Hntro6dFXCLgIrX9BwNRWaTLdX6TjSRCCmh2iibMk7+leg681pTmCxm8rTwJFYHwwHvmQV8XLxHwD+KNWHlogTmGyzSWgFYtKncBkOvRSwm4+YmfjW2dN2ODJcBGZZyzlF193KwK5SrpSeNRbwDmQNjKVEAVtz+Lw==
         home_dir: /srv/logs/log-1/defra_darwin


### PR DESCRIPTION
Apparently even in quotes colons aren't ok.
