### PR TITLE
Install cmake on the CI boxes

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -42,6 +42,7 @@ class ci_environment::jenkins_job_support {
     'libjpeg8-dev', # alphagov/screenshot-as-a-service
     'libpango1.0-dev', # alphagov/screenshot-as-a-service
     'libgif-dev', # alphagov/screenshot-as-a-service
+    'cmake', # alphagov/spotlight
   ])
 
   package { 'golang':


### PR DESCRIPTION
We need this to build alphagov/spotlight as it has a dependency on libgit2.
