### PR TITLE
Upgrade mongodb on slave-1

### DIFF
--- a/hieradata/role.ci-slave.1.yaml
+++ b/hieradata/role.ci-slave.1.yaml
@@ -1,6 +1,5 @@
 ---
-jenkins::slave::labels: '"mongodb-2.0.9 java6"'
+jenkins::slave::labels: '"mongodb-2.4 java6"'
 
-
-mongodb::version: 2.0.9
+mongodb::version: 2.4.9
 java::package: 'openjdk-6-jdk'


### PR DESCRIPTION
Now that most things (everything?) has been upgraded to mongo2.4 in
prod, it makes sense to have most of out CI boxes also running 2.4.

This leaves slave-3 running 2.0 for now so that any jobs still tied to
2.0 will continue to run.  That can beupgraded when there are no more
jobs that depend on 2.0.
