### PR TITLE
Fix ownership of /etc/init/xvfb.conf

### DIFF
--- a/modules/xvfb/manifests/service.pp
+++ b/modules/xvfb/manifests/service.pp
@@ -3,6 +3,8 @@ class xvfb::service {
 
   file { '/etc/init/xvfb.conf':
     ensure => present,
+    owner  => root,
+    group  => root,
     source => 'puppet:///modules/xvfb/xvfb.conf',
   }
 


### PR DESCRIPTION
Puppet defaults to the real uid, not the effective uid, for file owners.
Because we run puppet apply through sudo, this means that this file ends
up being owned by the user who ran the deploy.  I was alerted by this
line of output:

```
[ci-slave-1] out: Notice: /Stage[main]/Xvfb::Service/File[/etc/init/xvfb.conf]/owner: owner changed 'alexmuller' to 'ppotter'
```
