### PR TITLE
[#69995468] Backup CDN logs.

### DIFF
--- a/hieradata/role.transition-logs.yaml
+++ b/hieradata/role.transition-logs.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
  - cdn_logs
+ - cdn_logs::backup
  - git
  - ci_environment::transition_logs
  - ci_environment::firewall_config::transition_logs

--- a/modules/cdn_logs/manifests/backup.pp
+++ b/modules/cdn_logs/manifests/backup.pp
@@ -1,0 +1,17 @@
+#class to backup cdn logs.
+class cdn_logs::backup (
+  $log_dir = '/srv/logs/log-1/cdn',
+  $backup_target = false,
+){
+
+if $backup_target {
+    duplicity{'cdn':
+      directory => $log_dir,
+      target    => "${backup_target}/cdn",
+      hour      => 22,
+      minute    => 10,
+      pubkey_id => '13B84C37AB52D76B3F53CF0E7C34BD7A05119BA4',
+      require   => File[$log_dir],
+    }
+  }
+}


### PR DESCRIPTION
If a backup target is given use duplicity to backup the cdn logs directory.

relies on alphagov/ci-puppet#154 haivng been merged first.
