### PR TITLE
[#69996486] Make collectd collect disk stats.

### DIFF
--- a/modules/gds_collectd/manifests/init.pp
+++ b/modules/gds_collectd/manifests/init.pp
@@ -22,4 +22,6 @@ class gds_collectd {
   collectd::plugin {'memory':}
   collectd::plugin {'cpu':}
   collectd::plugin {'interface':}
+  collectd::plugin {'df':}
+  collectd::plugin {'disk':}
 }


### PR DESCRIPTION
Just load the df and disk plugins instead of using the custom configuration
classes for them because we dont need to configure them.
