### PR TITLE
Remove logs_processor from root group and add it to syslog group

### DIFF
--- a/modules/ci_environment/manifests/transition_logs.pp
+++ b/modules/ci_environment/manifests/transition_logs.pp
@@ -8,7 +8,7 @@ class ci_environment::transition_logs {
     account {
         'logs_processor':
             home_dir => $logs_processor_home,
-            groups   => [ 'root', 'adm' ],
+            groups   => [ 'syslog', 'adm' ],
             comment  => 'A user to process logs from Fastly and agencies and push into a GitHub repo',
             require  => File['/srv/logs/log-1'],
     }


### PR DESCRIPTION
Since making changes to the CDN log rotation, the logs are now owned
by syslog.syslog and logs_processor can't read them. Adding logs_processor
to the syslog group should solve this. There's no reason for this user
to be in the root group either.
