### PR TITLE
Fix tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,5 @@ gem 'puppet-syntax'
 gem 'puppet-lint', '~> 0.3.0'
 gem 'rspec-puppet', '~> 0.1.0'
 gem 'puppetlabs_spec_helper', '~> 0.4.0'
-gem "parallel_tests"
-gem "parallel"
+gem "parallel_tests", "~> 0.16.10"
+gem "parallel", "~> 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
+    diff-lcs (1.2.5)
     facter (1.6.18)
-    hiera (1.2.1)
+    hiera (1.3.2)
       json_pure
-    highline (1.6.19)
-    json (1.8.0)
-    json_pure (1.8.0)
-    librarian (0.1.1)
+    highline (1.6.21)
+    json_pure (1.8.1)
+    librarian (0.1.2)
       highline
       thor (~> 0.15)
-    librarian-puppet-maestrodev (0.9.10.1)
-      json
+    librarian-puppet-maestrodev (0.9.11.6)
       librarian (>= 0.1.1)
-    metaclass (0.0.1)
-    mocha (0.14.0)
+    metaclass (0.0.4)
+    mocha (1.1.0)
       metaclass (~> 0.0.1)
-    parallel (0.5.19)
-    parallel_tests (0.8.14)
+    parallel (1.0.0)
+    parallel_tests (0.16.10)
       parallel
     puppet (3.1.1)
       facter (~> 1.6)
       hiera (~> 1.0)
     puppet-lint (0.3.2)
-    puppet-syntax (0.0.4)
+    puppet-syntax (1.2.0)
       puppet (>= 2.7.0)
       rake
     puppetlabs_spec_helper (0.4.1)
@@ -32,18 +30,18 @@ GEM
       rake
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
-    rake (10.0.4)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
+    rake (10.3.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
+    rspec-mocks (2.14.6)
     rspec-puppet (0.1.6)
       rspec
-    thor (0.18.1)
+    thor (0.19.1)
 
 PLATFORMS
   ruby
@@ -51,8 +49,8 @@ PLATFORMS
 DEPENDENCIES
   facter (~> 1.6.0)
   librarian-puppet-maestrodev
-  parallel
-  parallel_tests
+  parallel (~> 1.0.0)
+  parallel_tests (~> 0.16.10)
   puppet (~> 3.1.0)
   puppet-lint (~> 0.3.0)
   puppet-syntax

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -13,7 +13,7 @@ namespace :spec do
     ENV['RUBYOPT'] = (ENV['RUBYOPT'] || '') + ' -W0'
 
     $stderr.puts '---> Running puppet specs'
-    ParallelTest::CLI.run(cli_args)
+    ParallelTests::CLI.new.run(cli_args)
   end
 
   desc "Run govuk::node class specs"


### PR DESCRIPTION
Travis ignores the Gemfile.lock, and we weren't pinning the version of
parallel and parallel_tests.  The api of these gems has changes with
recent versions, which has caused the tests to fail on Travis.

This PR pins the versions of parallel and parallel_tests, and also
updates the test runner to use the new API.
