### PR TITLE
7zip binary for pre-transition-stats tests

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -36,6 +36,7 @@ class ci_environment::jenkins_job_support {
     'libv8-dev', # Needed by things that require V8 headers
     'vegeta', # HTTP load testing used by Router.
     'mawk-1.3.4', # Provides /opt/mawk required by pre-transition-stats
+    'p7zip-full', # Provides /usr/bin/7z required by pre-transition-stats
     'php5-cli', # Needed by redirector
     'dnsutils', # Needed by transition_dns_report
     'libcairo2-dev', # alphagov/screenshot-as-a-service


### PR DESCRIPTION
- pre-transition-stats needs to decompress logs to console.
  Its specs test this and need the binary.
