### PR TITLE
Add mercurial to our CI environment

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -30,6 +30,7 @@ class ci_environment::base {
     'libxslt1-dev',
     'logtail',
     'lsof',
+    'mercurial',
     'pv',
     'tar',
     'tree',


### PR DESCRIPTION
This is required to fetch dependencies using `go get`.
