### PR TITLE
Run `apt-get update` before `puppet apply`

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -9,6 +9,8 @@ classes:
   - ci_environment::firewall_config::base
   - locales
 
+apt::always_apt_update: true
+
 jenkins::lts: 1
 
 locales::default_value: en_GB.UTF-8


### PR DESCRIPTION
In the event that we reference a package in a repository that we
haven't updated yet, running puppet apply will fail. To get around
this we should run apt-get update before trying to apply Puppet.
