### PR TITLE
[#53063007] Manage github-oauth plugin

### DIFF
--- a/hieradata/role.ci-master.yaml
+++ b/hieradata/role.ci-master.yaml
@@ -81,3 +81,5 @@ jenkins::plugin_hash:
         version: "0.2.0"
     build-pipeline-plugin:
         version: "1.3.3"
+    github-oauth:
+        version: "0.14"


### PR DESCRIPTION
This was vendored and installed as a file{} resource up until 31578e5. After
which it won't have been installed for new machines. Adding it here ensures
that it's installed and at the desired version.
