### PR TITLE
Use Strict-Transport-Security header

### DIFF
--- a/modules/ci_environment/manifests/jenkins_master.pp
+++ b/modules/ci_environment/manifests/jenkins_master.pp
@@ -39,6 +39,7 @@ class ci_environment::jenkins_master (
     isdefaultvhost => true,
     servername     => $jenkins_servername,
     serveraliases  => $jenkins_serveraliases,
+    magic          => 'add_header Strict-Transport-Security "max-age=31536000";'
   }
 
   file {'/etc/ssl/certs/github.gds.pem':


### PR DESCRIPTION
As James
I would like my browser to remember to use HTTPS
So that I don’t feel stupid when I forget to type https:// in the
address bar

I haven't been able to test this properly yet.

`vagrant up ci-master-1` does not result in nginx being installed.

Pointers appreciated.
