### PR TITLE
Track puppet/mysql

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/mysql.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/mysql.pp
@@ -1,13 +1,8 @@
 # == Class: ci_environment::jenkins_job_support::mysql
 # Installs mysql on the server
 class ci_environment::jenkins_job_support::mysql {
-  class { '::mysql': }
   class { '::mysql::server':
-    require     => Class['::mysql']
-  }
-
-  mysql::server::config { 'innodb':
-    settings => {
+    override_options => {
       'mysqld' => {
         'innodb_flush_log_at_trx_commit'     => '0',
       },


### PR DESCRIPTION
Not sure how this ever worked…

Fixes 

```
> vagrant provision ci-master-1
...
==> ci-master-1: Error: ERROR:  This class has been deprecated and the functionality moved
==> ci-master-1:     into mysql::server.  If you run mysql::server without correctly calling
==> ci-master-1:     mysql:: server with the new override_options hash syntax you will revert
==> ci-master-1:     your MySQL to the stock settings.  Do not proceed without removing this
==> ci-master-1:     class and using mysql::server correctly.
==> ci-master-1: 
==> ci-master-1:     If you are brave you may set attempt_compatibility_mode in this class which
==> ci-master-1:     attempts to automap the previous settings to appropriate calls to
==> ci-master-1:     mysql::server at /tmp/vagrant-puppet-3/modules-1/mysql/manifests/init.pp:89 on node ci-master-1.internal
```
