### PR TITLE
Add libffi-dev to ci slaves

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -44,6 +44,7 @@ class ci_environment::jenkins_job_support {
     'libpango1.0-dev', # alphagov/screenshot-as-a-service
     'libgif-dev', # alphagov/screenshot-as-a-service
     'cmake', # alphagov/spotlight
+    'libffi-dev', # alphagov/backdrop
   ])
 
   package { 'golang':


### PR DESCRIPTION
Backdrop now needs libffi-dev to build one of its dependencies
(pyOpenSSL)
