### PR TITLE
Create RabbitMQ user for govuk_seed_crawler

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/rabbitmq.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/rabbitmq.pp
@@ -6,13 +6,19 @@ class ci_environment::jenkins_job_support::rabbitmq {
   rabbitmq_user {
     'content_store':
       password => 'content_store';
+    'govuk_seed_crawler':
+      password => 'govuk_seed_crawler';
   }
 
   rabbitmq_user_permissions {
     'content_store@/':
       configure_permission => '^amq\.gen.*$',
       read_permission      => '^(amq\.gen.*|published_documents_test)$',
-      write_permission     => '^(amq\.gen.*|published_documents_test)$',
+      write_permission     => '^(amq\.gen.*|published_documents_test)$';
+    'govuk_seed_crawler@/':
+      configure_permission => '^govuk_seed_crawler.*',
+      read_permission      => '^govuk_seed_crawler.*',
+      write_permission     => '^govuk_seed_crawler.*';
   }
 
   gds_rabbitmq::exchange {


### PR DESCRIPTION
This will allow it to create exchanges and queues that are prefixed with
"govuk_seed_crawler". In my testing and I haven't found that it
creates/needs any automatically generated resources of the format "amq.gen"
