### PR TITLE
Bump bundler to 1.6.5

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -41,23 +41,23 @@ class ci_environment::base {
   ])
 
   rbenv::version { '1.9.3-p392':
-    bundler_version => '1.3.5'
+    bundler_version => '1.6.5'
   }
   rbenv::version { '1.9.3-p484':
-    bundler_version => '1.3.5'
+    bundler_version => '1.6.5'
   }
   rbenv::version { '1.9.3-p545':
-    bundler_version => '1.3.5'
+    bundler_version => '1.6.5'
   }
   rbenv::alias { '1.9.3':
     to_version => '1.9.3-p545',
   }
 
   rbenv::version { '2.0.0-p247':
-    bundler_version => '1.3.5'
+    bundler_version => '1.6.5'
   }
   rbenv::version { '2.0.0-p353':
-    bundler_version => '1.3.5'
+    bundler_version => '1.6.5'
   }
   rbenv::version { '2.0.0-p451':
     bundler_version => '1.5.3'
@@ -67,7 +67,7 @@ class ci_environment::base {
   }
 
   rbenv::version { '2.1.2':
-    bundler_version => '1.6.2',
+    bundler_version => '1.6.5',
   }
   rbenv::alias { '2.1':
     to_version => '2.1.2',


### PR DESCRIPTION
The current version of bundler is over a year out of date and the dependency resolution in newer versions is much better. Specifically, I'm having issues with the multi-ruby build version of gds-sso: https://github.com/alphagov/gds-sso/compare/multi-rails. Newer version of bundler correctly resolve the dependencies.

The main puppet repo has a separate pull request to bump the version on the rest of our infrastructure to match the version here.
