### PR TITLE
Create transition's postgres role before using it as owner

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/postgresql.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/postgresql.pp
@@ -5,11 +5,18 @@ class ci_environment::jenkins_job_support::postgresql {
   include postgresql::server::contrib
   include postgresql::lib::devel
 
+  $transition_password = postgresql_password('transition', 'transition')
+
+  postgresql::server::role { 'transition':
+    password_hash => $transition_password,
+  }
+
   postgresql::server::db { 'transition_test':
     encoding => 'UTF8',
     owner    => 'transition',
-    password => postgresql_password('transition', 'transition'),
+    password => $transition_password,
     user     => 'transition',
+    require  => [Class['govuk_postgresql::server'], Postgresql::Server::Role['transition']],
   }
 
   exec { 'Load pgcrypto for postgres db transition_test':


### PR DESCRIPTION
We have seen failures on an initial Puppet run if the role isn't
created before the database is created with the role as its owner.
This brings this postgres db setup in line with what we have currently
in GOV.UK puppet.
