### PR TITLE
Change how postgres permissions are handled

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/postgresql.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/postgresql.pp
@@ -9,31 +9,8 @@ class ci_environment::jenkins_job_support::postgresql {
   $url_arbiter_password = postgresql_password('url-arbiter', 'url-arbiter')
 
   postgresql::server::role {
-    'transition':
-      password_hash => $transition_password;
-    'url-arbiter':
-      password_hash => $url_arbiter_password;
-  }
-
-  postgresql::server::db {
-    'transition_test':
-      encoding => 'UTF8',
-      owner    => 'transition',
-      password => $transition_password,
-      user     => 'transition',
-      require  => [Class['postgresql::server'], Postgresql::Server::Role['transition']];
-    'url-arbiter_test':
-      encoding => 'UTF8',
-      owner    => 'url-arbiter',
-      password => $url_arbiter_password,
-      user     => 'url-arbiter',
-      require  => [Class['postgresql::server'], Postgresql::Server::Role['url-arbiter']];
-  }
-
-  exec { 'Load pgcrypto for postgres db transition_test':
-    user    => 'postgres',
-    command => 'psql -d transition_test -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"',
-    unless  => 'psql -d transition_test -c "\dx" | grep -q pgcrypto',
-    require => Postgresql::Server::Db['transition_test'],
+    'jenkins':
+      password_hash => postgresql_password('jenkins', 'jenkins'),
+      createdb      => true;
   }
 }


### PR DESCRIPTION
By allowing the jenkins user createdb permissions, we can use the
standard Rails rake tasks to create/drop databases etc.  This will also
allow using ident auth and therefore avoid having to specify
usernames/passwords in the database.yml.

/cc @jennyd 
