### PR TITLE
[#76238036] Fix regex escapes in Puppet RabbitMQ module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -13,7 +13,9 @@ mod 'puppetlabs/java',             '0.3.0'
 mod 'puppetlabs/mysql',            '0.9.0'
 mod 'puppetlabs/nodejs',           '0.4.0'
 mod 'puppetlabs/postgresql'
-mod 'puppetlabs/rabbitmq'
+mod 'puppetlabs/rabbitmq',
+  :git => 'git://github.com/alphagov/puppetlabs-rabbitmq.git',
+  :ref => 'strip-backslashes'
 mod 'puppetlabs/stdlib',           '~> 4.0'
 mod 'saz/dnsmasq',                 '1.0.1'
 

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -12,7 +12,7 @@ FORGE
     gdsoperations/openconnect (1.0.0)
       puppetlabs/stdlib (>= 3.0.0)
     gdsoperations/rbenv (1.0.1)
-    nanliu/staging (0.4.0)
+    nanliu/staging (0.4.1)
     pdxcat/collectd (0.0.3)
       puppetlabs/stdlib (>= 2.0.0)
     puppetlabs/apt (1.3.0)
@@ -33,10 +33,6 @@ FORGE
       puppetlabs/concat (< 2.0.0, >= 1.0.0)
       puppetlabs/firewall (>= 0.0.4)
       puppetlabs/stdlib (< 5.0.0, >= 3.2.0)
-    puppetlabs/rabbitmq (4.0.0)
-      nanliu/staging (>= 0.3.1)
-      puppetlabs/apt (>= 1.0.0)
-      puppetlabs/stdlib (>= 2.0.0)
     puppetlabs/stdlib (4.1.0)
     saz/dnsmasq (1.0.1)
     torrancew/account (0.0.5)
@@ -116,6 +112,16 @@ GIT
   specs:
     alphagov/mongodb (0.1.0)
       puppetlabs/apt (>= 0.0.2)
+
+GIT
+  remote: git://github.com/alphagov/puppetlabs-rabbitmq.git
+  ref: strip-backslashes
+  sha: 72785de752337ef050f0ec5462f96d21ac8e8ce6
+  specs:
+    puppetlabs/rabbitmq (4.0.0)
+      nanliu/staging (>= 0.3.1)
+      puppetlabs/apt (>= 1.0.0)
+      puppetlabs/stdlib (>= 2.0.0)
 
 GIT
   remote: git://github.com/gds-operations/puppet-graphite.git


### PR DESCRIPTION
Update the `Puppetfile` to use our own fork of the `puppetlabs-rabbitmq`
module which includes a fix to strip extraneous escaping backslashes
from the output of `rabbitmqctl(1)`[1].

The output of `rabbitmqctl(1)` escapes backslashes. This was documented
in the `rabbitmqctl` man page[2] but was removed when the manpage was
converted to DocBook XML[3].

Tested using our `noop_deploy` Fabric task, before this change:

```
[ci-slave-4] out: Notice:
/Stage[main]/Ci_environment::Jenkins_job_support::Rabbitmq/Rabbitmq_user_permissions[content_store@/]/configure_permission:
current_value ^amq\\.gen.*$, should be ^amq\.gen.*$ (noop)
[ci-slave-4] out: Notice:
/Stage[main]/Ci_environment::Jenkins_job_support::Rabbitmq/Rabbitmq_user_permissions[content_store@/]/read_permission:
current_value ^(amq\\.gen.*|published_documents_test)$, should be
^(amq\.gen.*|published_documents_test)$ (noop)
[ci-slave-4] out: Notice:
/Stage[main]/Ci_environment::Jenkins_job_support::Rabbitmq/Rabbitmq_user_permissions[content_store@/]/write_permission:
current_value ^(amq\\.gen.*|published_documents_test)$, should be
^(amq\.gen.*|published_documents_test)$ (noop)
```

With this change, the RabbitMQ permissions are left as-is (a noop).

[1]:
https://github.com/alphagov/puppetlabs-rabbitmq/commit/72785de752337ef050f0ec5462f96d21ac8e8ce6#diff-d41d8cd98f00b204e9800998ecf8427e
[2]:
https://github.com/rabbitmq/rabbitmq-server/blob/16418a9488e15c4d8ef3bfa9fce69190fb8ec796/docs/rabbitmqctl.1.pod#output-escaping
[3]:
rabbitmq/rabbitmq-server@60c14ba#diff-b96d4e7ccd3d984656b8ab3534e6b460
