### PR TITLE
[#76422752] Add the ability to ensure supported kernel

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -90,6 +90,18 @@ class ci_environment::base {
 
   include ssh::server
 
+  # Required for hwe-support-status script
+  package {'update-manager-core':
+    ensure => present,
+  }
+  $latest_lte_supported = 'trusty'
+  # Force us to a kernel that is 'supported', requires a reboot to be certain
+  package {["linux-generic-lts-${latest_lte_supported}", "linux-image-generic-lts-${latest_lte_supported}"]:
+    ensure  => present,
+    require => Package['update-manager-core'],
+    unless  => '/usr/bin/hwe-support-status',
+  }
+
   exec { 'apt-get-update':
     command => '/usr/bin/apt-get update || true',
   }


### PR DESCRIPTION
Ubuntu has [deprecated](https://wiki.ubuntu.com/1204_HWE_EOL) all hardware enablement (HWE) kernels which are basically the kernels for newer releases backported to this release. They are named with suffixes of _lts-quantal_, _lts-raring_, _lts_saucy_ and those kernels are only supported until 14.04.1 is released (Aug 8, 2014)

As we are using the original kernel series supplied with 12.04 and that is still supported until April 2017, we don't need to do anything, and this PR is actually a NOOP. However this PR ensures that if `hwe-support-status` changes in future, our kernel will be updated and serves as a model for other environments where we _do_ need to make this change.

```
ssharpe@ci-master-1:~$ hwe-support-status --verbose
You are not running a system with a Hardware Enablement Stack. Your
system is supported until April 2017.
```

If we did upgrade to _lts-trusty_ packages, then we would still be supported until April 2017 (as that is the EOS for Ubuntu 12.04 Precise)
