### PR TITLE
[#76261684] Allow govuk_crawler_worker RabbitMQ mgmt perms

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/rabbitmq.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/rabbitmq.pp
@@ -9,7 +9,8 @@ class ci_environment::jenkins_job_support::rabbitmq {
     'govuk_seed_crawler':
       password => 'govuk_seed_crawler';
     'govuk_crawler_worker':
-      password => 'govuk_crawler_worker';
+      password => 'govuk_crawler_worker',
+      tags     => ['monitoring'];
   }
 
   rabbitmq_user_permissions {


### PR DESCRIPTION
Allow the `govuk_crawler_worker` RabbitMQ user access to the RabbitMQ management API[1](https://www.rabbitmq.com/management.html), giving it the rights to kill its own connections and channels.

This is needed for CI tests for the GOV.UK Crawler Worker.
