### PR TITLE
Add the ability to ensure supported kernel

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -90,6 +90,12 @@ class ci_environment::base {
 
   include ssh::server
 
+  $latest_lte_supported = 'trusty'
+  # Force us to a kernel that is 'supported', requires a reboot to be certain
+  package {["linux-generic-lts-${latest_lte_supported}", "linux-image-generic-lts-${latest_lte_supported}", 'update-manager-core']:
+    ensure  => present,
+  }
+
   exec { 'apt-get-update':
     command => '/usr/bin/apt-get update || true',
   }


### PR DESCRIPTION
Ubuntu has [deprecated](https://wiki.ubuntu.com/1204_HWE_EOL) all hardware enablement (HWE) kernels (except those which come from LTS releases) which are basically the kernels for newer releases backported to this release. They are named with suffixes of _lts-quantal_, _lts-raring_, _lts-saucy_ and those kernels were only supported until 14.04.1 is released (Aug 8, 2014). The _lts-trusty_ kernel is supported on Ubuntu 12.04 (Precise) because it is backported from Ubuntu 14.04 (Trusty) which is also a Long-Term Support release.

See also #202 for context - the kernel currently on these machines is the original precise kernel which is still supported, however we are forcing them to lts-trusty for consistency with the rest of our estate.
