### PR TITLE
Remove redirector-as-an-app dependencies

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -22,8 +22,6 @@ mod 'saz/dnsmasq',                 '1.0.1'
 
 mod 'alphagov/clamav',        :git => 'git://github.com/alphagov/puppet-clamav',
                               :ref => '31af4f0c2753dd25bca3dd0c7cc69d273c4d640d'
-mod 'alphagov/cpanm',         :git => 'git://github.com/alphagov/puppet-cpanm.git',
-                              :ref => '4e3dfca9b5ca25da71a78412305710e665475698'
 mod 'alphagov/duplicity',     :git => 'git@github.com:alphagov/puppet-duplicity.git',
                               :ref => 'b9ea2e67ed1bb293fc3e13d4ba20ba3fc0f199f9'
 mod 'alphagov/ext4mount',     :git => 'git://github.com/alphagov/puppet-ext4mount.git'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -48,13 +48,6 @@ GIT
       puppetlabs/stdlib (>= 3.0.0)
 
 GIT
-  remote: git://github.com/alphagov/puppet-cpanm.git
-  ref: 4e3dfca9b5ca25da71a78412305710e665475698
-  sha: 4e3dfca9b5ca25da71a78412305710e665475698
-  specs:
-    alphagov/cpanm (0.0.1)
-
-GIT
   remote: git://github.com/alphagov/puppet-ext4mount.git
   ref: master
   sha: d97f99cc2801b83152b905d1285fa34e689cb499
@@ -157,7 +150,6 @@ GIT
 
 DEPENDENCIES
   alphagov/clamav (>= 0)
-  alphagov/cpanm (>= 0)
   alphagov/duplicity (>= 0)
   alphagov/ext4mount (>= 0)
   alphagov/gds_accounts (>= 0)

--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -7,9 +7,6 @@
 #  that requires them
 #
 class ci_environment::jenkins_job_support {
-  # redirector's tests require some Perl packages (see below)
-  include cpanm::install
-
   # should be used to install gems in jenkins build scripts
   package { 'bundler':
     ensure   => '1.1.4',
@@ -37,8 +34,6 @@ class ci_environment::jenkins_job_support {
     'vegeta', # HTTP load testing used by Router.
     'mawk-1.3.4', # Provides /opt/mawk required by pre-transition-stats
     'p7zip-full', # Provides /usr/bin/7z required by pre-transition-stats
-    'php5-cli', # Needed by redirector
-    'dnsutils', # Needed by transition_dns_report
     'libcairo2-dev', # alphagov/screenshot-as-a-service
     'libjpeg8-dev', # alphagov/screenshot-as-a-service
     'libpango1.0-dev', # alphagov/screenshot-as-a-service
@@ -74,18 +69,6 @@ class ci_environment::jenkins_job_support {
   class { 'ci_environment::jenkins_job_support::rabbitmq': }
   class { 'phantomjs': }
   class { 'xvfb': } # Needed by capybara-webkit (used in Publisher)
-
-  # redirector's tests require these Perl packages
-  package { [
-    'Text::CSV',
-    'YAML',
-    'Crypt::SSLeay',
-    'Mozilla::CA',
-    'XML::Parser',
-  ]:
-    ensure   => present,
-    provider => 'cpanm',
-  }
 
   class { 'clamav': }
 


### PR DESCRIPTION
The redirector repository will live on, but it is now dead as an app. It will
still have a CI build, but it has generic Ruby dependencies.
