### PR TITLE
Remove rbenv-ruby-2.0.0-p247

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -53,8 +53,9 @@ class ci_environment::base {
     to_version => '1.9.3-p545',
   }
 
-  rbenv::version { '2.0.0-p247':
-    bundler_version => '1.6.5'
+  # FIXME remove once cleaned up everywhere
+  package { 'rbenv-ruby-2.0.0-p247':
+    ensure => purged,
   }
   rbenv::version { '2.0.0-p353':
     bundler_version => '1.6.5'


### PR DESCRIPTION
It's not being used anywhere any more[1].  Removing it saves us having to
maintain one more debian package

[1] https://github.com/search?utf8=%E2%9C%93&q=user%3Aalphagov+2.0.0-p247&type=Code&ref=searchresults
