### PR TITLE
Add a transition-logs upload user for KTP

### DIFF
--- a/hieradata/role.transition-logs.yaml
+++ b/hieradata/role.transition-logs.yaml
@@ -165,3 +165,10 @@ ci_environment::transition_logs::rssh_users:
         comment: "The Charity Commission"
         ssh_key: AAAAB3NzaC1yc2EAAAABJQAAAQEAis6f9D82TxDgMh3mUY9CTxQYZ45O8gWUvlYAp9yvuoYjZ9e4cJgDzi+//5ig59VE/Az5vZyqORCx9WDwpuukE7KM57WLuypUl6jMrHxvdzIgQb03QGPsZYP14vVRcPdYunnhXm9XwykPpJLEfktBmYRcUyUyLbbqThU6Z+zvTtIr7SRA6RVx0L1qd6Z9kMpFemAwDDadRZzaoTVDzMbBrEt7WlBBKoLouWOekzaP+OHX7u/Da+0jdA1M90tr/7TjLfKiQGvpHNYkipCZPjjJm0PGiTjs3KpZHOHKAD7mONqc7FN8JZtyOqQ72+GLPxgCvAode64AOjrd6i8N5iNFXQ==
         home_dir: /srv/logs/log-1/charity_commission
+
+    # Note that ktp's ssh_key is actually @rgarner's. They've given us ad-hoc log files
+    # to upload.
+    ktp:
+        comment: Innovate UK Knowledge Transfer Partnerships
+        ssh_key: AAAAB3NzaC1yc2EAAAABIwAAAQEAuoIglteQmEwL5/T3maYcomkZs44x1Rx/YRn31vMEuAaBHqYyD5mLUFMXQbCyFO6mZcjx+uOTOT6QhzIiKa8dJhAs5K/KFtjG/6vuwqFdC/Tpggvx6My/vDROsZVmPz4RFrd9XhoL2ybAXaHq6hfo+j112J/n+rkemqzmR/gz2TGFni9jSWG8fEzEkMwQR0iHZnGSFJI2UUR8trxyk32Pq3hkyEiA+XdipR/U8uPnBB2C3+Ms5NUaI8kFmQKYEumqU093dUD7iuekw3vA3elD8oR6UeDGcoRbMomT8oaatPtZl2rSw343M+tEQTC4VsUtcYAiK46sCxIsSjCI0+k2eQ==
+        home_dir: /srv/logs/log-1/ktp


### PR DESCRIPTION
We've got ad-hoc logs, they won't be uploading themselves.
