### PR TITLE
Add RabbitMQ permissions for the email alert service.

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/rabbitmq.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/rabbitmq.pp
@@ -18,6 +18,10 @@ class ci_environment::jenkins_job_support::rabbitmq {
       configure_permission => '^amq\.gen.*$',
       read_permission      => '^(amq\.gen.*|published_documents_test)$',
       write_permission     => '^(amq\.gen.*|published_documents_test)$';
+    'email_alert_service_test@/':
+      configure_permission => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue)$',
+      read_permission      => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue)$',
+      write_permission     => '^(amq\.gen.*|email_alert_service_published_documents_test_exchange|email_alert_service_published_documents_test_queue)$';
     'govuk_seed_crawler@/':
       configure_permission => '^govuk_seed_crawler.*',
       read_permission      => '^govuk_seed_crawler.*',
@@ -30,6 +34,12 @@ class ci_environment::jenkins_job_support::rabbitmq {
 
   gds_rabbitmq::exchange {
     'published_documents_test@/':
+      ensure   => present,
+      type     => 'topic';
+  }
+
+  gds_rabbitmq::exchange {
+    'email_alert_service_published_documents_test_exchange@/':
       ensure   => present,
       type     => 'topic';
   }


### PR DESCRIPTION
The obnoxiously long names are a side effect of needing them to be unique both across apps and functionally within an app to avoid concurrency clashes.

We're looking at ways to mitigate this and improve test/prod parity.
