### PR TITLE
Really remove ruby 2.0.0-p247

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -57,6 +57,11 @@ class ci_environment::base {
   package { 'rbenv-ruby-2.0.0-p247':
     ensure => purged,
   }
+  file { '/usr/lib/rbenv/versions/2.0.0-p247':
+    ensure => absent,
+    force  => true,
+  }
+
   rbenv::version { '2.0.0-p353':
     bundler_version => '1.6.5'
   }


### PR DESCRIPTION
The existing removal removed the package, but left behind other files
that are outside the package - mostly just bundler. This cleans these up
as well.
