### PR TITLE
Upgrade mongo as per the other slaves

### DIFF
--- a/hieradata/role.ci-slave.1.yaml
+++ b/hieradata/role.ci-slave.1.yaml
@@ -1,5 +1,4 @@
 ---
 jenkins::slave::labels: '"mongodb-2.4 java6"'
 
-mongodb::version: 2.4.9
 java::package: 'openjdk-6-jdk'

--- a/hieradata/role.ci-slave.2.yaml
+++ b/hieradata/role.ci-slave.2.yaml
@@ -1,5 +1,4 @@
 ---
 jenkins::slave::labels: '"mongodb-2.4 rabbitmq java6"'
 
-mongodb::version: 2.4.9
 java::package: 'openjdk-6-jdk'

--- a/hieradata/role.ci-slave.3.yaml
+++ b/hieradata/role.ci-slave.3.yaml
@@ -1,4 +1,2 @@
 ---
 jenkins::slave::labels: 'mongodb-2.4'
-
-mongodb::version: 2.4.9

--- a/hieradata/role.ci-slave.4.yaml
+++ b/hieradata/role.ci-slave.4.yaml
@@ -1,4 +1,2 @@
 ---
 jenkins::slave::labels: '"mongodb-2.4 cdn-acceptance-test"'
-
-mongodb::version: 2.4.9

--- a/hieradata/role.ci-slave.yaml
+++ b/hieradata/role.ci-slave.yaml
@@ -14,6 +14,7 @@ jenkins::slave::slave_home: /home/jenkins
 jenkins::slave::version: 1.9
 mongodb::replSet: 'gds-ci'
 mongodb::enable_10gen: true
+mongodb::version: 2.4.9
 gds_mongodb::members: ['localhost']
 gds_mongodb::replSet: 'gds-ci'
 


### PR DESCRIPTION
`ci-slave-3` was pinned to mongo 2.0.9. I think this is because was thought that this was required for the Licensify tests; and the [Licensify preview deploy job](https://ci-new.alphagov.co.uk/view/Licensing/job/Licensify/) was pinned to ci-slave-3.

However, [Licensify is now running on 2.4.9 in production](https://www.pivotaltracker.com/n/projects/524141/stories/65956934). When I [ran the Licensify job against ci-slave-1](https://ci-new.alphagov.co.uk/view/Licensing/job/Licensify/11656/consoleFull), which has a mongo version of 2.4.9, it passed.

If Licensify is the only reason that `ci-slave-3` has a mongo version of 2.0.9, then this restriction can be removed, which is what this PR does.

However, this raises another question - now there is nothing to distinguish the four slaves from each other in terms of mongo, and there is nothing to distinguish ci-slave-3 at all. So should I in fact be deleting all the configuration from `role.ci-slave.3.yaml` and setting them all to 2.4.9 further up? If so, where?

NB: I have now unpinned the Licensify job; it can now run on any of the Jenkins boxes.
