### PR TITLE
Upgrade Node.js from 0.10.29 to 0.10.32

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -119,7 +119,7 @@ class ci_environment::jenkins_job_support {
   # uglifier requires a JavaScript runtime
   # alphagov/spotlight requires a decent version of Node (0.10+) and grunt-cli
   package { 'nodejs':
-    ensure => "0.10.29-1chl1~${::lsbdistcodename}1",
+    ensure => "0.10.32-1chl1~${::lsbdistcodename}1",
   }
   package { 'grunt-cli':
     ensure   => '0.1.9',


### PR DESCRIPTION
Pull in the latest and greatest. I've added this to the PPA:

https://launchpad.net/~gds/+archive/ci

As far as I'm aware there are no applications that have a specific version dependency for Node.js, and Performance Platform are the heaviest users.
