### PR TITLE
Ensure apt-get update runs before package installs.

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -3,3 +3,16 @@ import 'nodes'
 Exec {
   path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
 }
+
+# Ensure update is always run before any package installs.
+# title conditions prevent a dependency loop within apt module.
+Class['apt::update'] -> Package <|
+  provider != pip and
+  provider != gem and
+  provider != system_gem and
+  ensure != absent and
+  ensure != purged and
+  title != 'python-software-properties' and
+  title != 'software-properties-common' and
+  tag != 'no_require_apt_update'
+|>


### PR DESCRIPTION
Without this, apt-get update can run after attempting to install a
package, meaning that the package install can fail.

This is lifted straight from the main puppet repo.
