### PR TITLE
Remove duplicated method for forcing apt-get update.

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -101,9 +101,4 @@ class ci_environment::base {
   package {["linux-generic-lts-${latest_lte_supported}", "linux-image-generic-lts-${latest_lte_supported}", 'update-manager-core']:
     ensure  => present,
   }
-
-  exec { 'apt-get-update':
-    command => '/usr/bin/apt-get update || true',
-  }
-  Exec <| title == 'apt-get-update' |> -> Package <| provider == 'apt' |>
 }


### PR DESCRIPTION
This wasn't working in all cases, and has been superceeded by #224
