### PR TITLE
Add latest rubies to ci_environment

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -49,8 +49,11 @@ class ci_environment::base {
   rbenv::version { '1.9.3-p545':
     bundler_version => '1.6.5'
   }
+  rbenv::version { '1.9.3-p550':
+    bundler_version => '1.7.4'
+  }
   rbenv::alias { '1.9.3':
-    to_version => '1.9.3-p545',
+    to_version => '1.9.3-p550',
   }
 
   rbenv::version { '2.0.0-p353':
@@ -59,18 +62,31 @@ class ci_environment::base {
   rbenv::version { '2.0.0-p451':
     bundler_version => '1.5.3'
   }
+  rbenv::version { '2.0.0-p594':
+    bundler_version => '1.7.4'
+  }
   rbenv::alias { '2.0.0':
-    to_version => '2.0.0-p451',
+    to_version => '2.0.0-p594',
   }
 
   rbenv::version { '2.1.2':
     bundler_version => '1.6.5',
   }
-  rbenv::version { '2.1.3':
-    bundler_version => '1.7.3',
+  rbenv::version { '2.1.4':
+    bundler_version => '1.7.4'
   }
   rbenv::alias { '2.1':
-    to_version => '2.1.3',
+    to_version => '2.1.4'
+  }
+
+  # FIXME: remove once this is cleaned up everywhere
+  package { 'rbenv-ruby-2.1.3':
+    ensure => purged,
+  }
+  file { '/usr/lib/rbenv/versions/2.1.3':
+    ensure  => absent,
+    force   => true,
+    require => Package['rbenv-ruby-2.1.3'],
   }
 
   file { '/etc/sudoers.d/gds':


### PR DESCRIPTION
This adds ruby 2.1.4, 2.0.0-p594, 1.9.3-p550 to all the machines.  It
additionally removes 2.1.3, as this has only just been added, and isn't
used by anything yet.

These new releases include a change to the openssl library to disable
insecure SSL/TLS options in response to POODLE[1].  They also include a
fix for a REXML DoS vulnerability[2]

[1] https://www.ruby-lang.org/en/news/2014/10/27/changing-default-settings-of-ext-openssl/
[2] https://www.ruby-lang.org/en/news/2014/10/27/rexml-dos-cve-2014-8080/
