### PR TITLE
Remove FIXMEd absent file resource

### DIFF
--- a/modules/cdn_logs/manifests/init.pp
+++ b/modules/cdn_logs/manifests/init.pp
@@ -59,11 +59,6 @@ class cdn_logs (
     proto => 'tcp',
   }
 
-  # FIXME: once deployed this can be removed
-  file { '/etc/logrotate.d/cdn_logs':
-    ensure  => absent,
-  }
-
   file { '/etc/logrotate.cdn_logs.conf':
     ensure  => file,
     content => template('cdn_logs/etc/logrotate.cdn_logs.conf.erb'),


### PR DESCRIPTION
This was deployed a long time ago and can be safely removed now.
