### PR TITLE
Add 'remove_older_than' param to Duplicity resources

### DIFF
--- a/modules/cdn_logs/manifests/backup.pp
+++ b/modules/cdn_logs/manifests/backup.pp
@@ -6,12 +6,13 @@ class cdn_logs::backup (
 
 if $backup_target {
     duplicity{'cdn':
-      directory => $log_dir,
-      target    => "${backup_target}/cdn",
-      hour      => 22,
-      minute    => 10,
-      pubkey_id => '13B84C37AB52D76B3F53CF0E7C34BD7A05119BA4',
-      require   => File[$log_dir],
+      directory         => $log_dir,
+      target            => "${backup_target}/cdn",
+      hour              => 22,
+      minute            => 10,
+      pubkey_id         => '13B84C37AB52D76B3F53CF0E7C34BD7A05119BA4',
+      remove_older_than => '30D',
+      require           => File[$log_dir],
     }
   }
 }

--- a/modules/ci_environment/manifests/transition_logs/remote_users.pp
+++ b/modules/ci_environment/manifests/transition_logs/remote_users.pp
@@ -33,12 +33,13 @@ define ci_environment::transition_logs::remote_users (
 
   if $backup_target {
     duplicity{$name:
-      directory => $home_dir,
-      target    => "${backup_target}/${name}",
-      hour      => $hour,
-      minute    => $min,
-      pubkey_id => '13B84C37AB52D76B3F53CF0E7C34BD7A05119BA4',
-      require   => Account[$name],
+      directory         => $home_dir,
+      target            => "${backup_target}/${name}",
+      hour              => $hour,
+      minute            => $min,
+      pubkey_id         => '13B84C37AB52D76B3F53CF0E7C34BD7A05119BA4',
+      remove_older_than => '30D',
+      require           => Account[$name],
     }
   }
 }


### PR DESCRIPTION
Duplicity resources should have a `remove_older_than` param to remove
backups that are older than a pre-set value.

The value is set to 30D (30 days) to ensure that we:
- are consistent across repos, and
- are regularly taking full backups instead of relying on incrementals over
  longer periods of time
