### PR TITLE
[#82935274] Define all CI machines in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,9 @@ def vagrant_config(config, version)
     'ci-master-1' => {:ip => '172.16.11.10'},
     'ci-slave-1'  => {:ip => '172.16.11.11'},
     'ci-slave-2'  => {:ip => '172.16.11.12'},
-    'ci-management-1' => {:ip => '172.16.11.13'},
+    'ci-slave-3'  => {:ip => '172.16.11.13'},
+    'ci-slave-4'  => {:ip => '172.16.11.14'},
+    'ci-management-1' => {:ip => '172.16.11.09'},
     'transition-logs-1' => {:ip => '172.16.11.20',
                             :extra_disks => [
                               { :name => 'sdb', :size => '524288'},


### PR DESCRIPTION
Add definitions for all of our CI machines to the Vagrantfile, so that
we can test all of these nodes.

Note that I've changed the IP that `ci-management-1` uses so that the
IPs used by the CI slaves are consecutive. This shouldn't have any
effect as the IPs here don't correspond to those used in the real
environment anyway.
