### PR TITLE
[#82935274] Remove hardcoded user

### DIFF
--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -32,18 +32,6 @@ check_ruby() {
     apt-get install -qq ruby1.9.1 2>&1 | pp
 }
 
-create_user() {
-  getent group gds >/dev/null || groupadd gds
-  getent passwd $1 >/dev/null || useradd -G gds -s /bin/bash -m $1
-  test -d /home/${1}/.ssh ||  mkdir /home/${1}/.ssh
-  echo "ssh-rsa $2 ${1} SSH Key" > /home/${1}/.ssh/authorized_keys
-  chmod 700 /home/${1}/.ssh
-  chmod 644 /home/${1}/.ssh/authorized_keys
-  chown -R $1 /home/${1}/.ssh
-  echo "%gds ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/gds
-  chmod 0440 /etc/sudoers.d/gds
-}
-
 fix_hostname() {
   MYFQDN=$1
   MYHOSTNAME=${MYFQDN%%.*}
@@ -82,7 +70,6 @@ main() {
   if [ "$1" != "unset" ]; then
     fix_hostname $1
   fi
-  create_user ssharpe 'AAAAB3NzaC1yc2EAAAABIwAAAQEAyNoMftFLf3w0NOW7J0KUwOx9897CU352n3zKD3p/GCcdH4eMv1QI0BhjItZplWG8TzFSBfWOOSruRh1Gksa1l1jiQcisEio6Wr7kZ7bpvMMA45ZoaDc26HTB+r0BZkNn7Lwwxxvy+1pbqStnnKzb9OTYIyVkb495LS0x1EL/P9S/NWtpm8ZULa1JDplYMA5SqMZnhmlGAXdh8UnjdcdOgOm2ngA+geJBSzVbABECiIAklHU1PRzOtrq8SuO8JmXW6NkuL0aabdTgE6noIm+Nn7T5ufZpOpIGYimVI8+mu+efcBzAp5Q0vTRgSBLfggdczZbFfPXpIt1Ib+LEf+Cuqw=='
 }
 
 if [ $# -eq 1 ]; then


### PR DESCRIPTION
**DEPENDS ON [ci-deployment#35](https://github.gds/gds/ci-deployment/pull/35)**

Under Vagrant, we can log in as the `vagrant` user. In a production
environment, individual user accounts will be created by Puppet.

See also this commit, which enables staff members to login using SSH key
authentication as the `ubuntu` user so that Puppet can be run for the
first time (at which point individual user accounts are created and the
`ubuntu` user is disabled):
https://github.gds/gds/ci-deployment/commit/a958d2edb95e5b8cb8f6a4f078d95ec8ab8e7d9d
