### PR TITLE
[#82935274] Notify dnsmasq service after configuration changes

### DIFF
--- a/modules/ci_environment/manifests/dns.pp
+++ b/modules/ci_environment/manifests/dns.pp
@@ -19,7 +19,7 @@ class ci_environment::dns {
 
   file { '/etc/hosts.dns':
     content => $hosts,
-    notify  => Class['dnsmasq::service'],
+    notify  => Class['dnsmasq'],
   }
 
   $nameservers = hiera('nameservers', ['8.8.8.8', '8.8.4.4'])
@@ -36,7 +36,7 @@ class ci_environment::dns {
     group   => 'root',
     mode    => '0644',
     content => template('ci_environment/resolv.conf.erb'),
-    notify  => Class['dnsmasq::service'],
+    notify  => Class['dnsmasq'],
   }
 
 }


### PR DESCRIPTION
`ci-master-1` could not recognise a new CI slave that I brought up until
I restarted `dnsmasq`. We should notify the service on any configuration
changes.
