### PR TITLE
[#82935274] Upgrade Puppet in Gemfile to version 3.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org'
 # advisable to pin major versions in this Gemfile.
 
 # Puppet core.
-gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.1.0'
-gem 'facter', ENV['FACTER_VERSION'] || '~> 1.6.0'
+gem 'puppet', ENV['PUPPET_VERSION'] || '= 3.7.1'
+gem 'facter', ENV['FACTER_VERSION'] || '= 2.2.0'
 
 # Dependency management.
 gem "librarian-puppet", '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.2.8)
     activemodel (4.1.8)
       activesupport (= 4.1.8)
       builder (~> 3.1)
@@ -12,7 +13,8 @@ GEM
       tzinfo (~> 1.1)
     builder (3.2.2)
     diff-lcs (1.2.5)
-    facter (1.6.18)
+    facter (2.2.0)
+      CFPropertyList (~> 2.2.6)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     her (0.7.2)
@@ -20,7 +22,7 @@ GEM
       activesupport (>= 3.0.0, < 4.2)
       faraday (>= 0.8, < 1.0)
       multi_json (~> 1.7)
-    hiera (1.3.2)
+    hiera (1.3.4)
       json_pure
     highline (1.6.21)
     i18n (0.6.11)
@@ -42,9 +44,10 @@ GEM
     parallel (1.0.0)
     parallel_tests (0.16.10)
       parallel
-    puppet (3.1.1)
-      facter (~> 1.6)
+    puppet (3.7.1)
+      facter (> 1.6, < 3)
       hiera (~> 1.0)
+      json_pure
     puppet-lint (0.3.2)
     puppet-syntax (1.2.0)
       puppet (>= 2.7.0)
@@ -77,11 +80,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  facter (~> 1.6.0)
+  facter (= 2.2.0)
   librarian-puppet (~> 2.0)
   parallel (~> 1.0.0)
   parallel_tests (~> 0.16.10)
-  puppet (~> 3.1.0)
+  puppet (= 3.7.1)
   puppet-lint (~> 0.3.0)
   puppet-syntax
   puppetlabs_spec_helper (~> 0.4.0)


### PR DESCRIPTION
Upgrade Puppet and Facter to match the versions supplied by the Vagrant
box templates we're using.

I'm specifying the exact versions so that we can use the exact same
versions as used by the Vagrant boxes.

I have tested this under Vagrant on the `ci-master`, `ci-slave-1`,
`ci-slave-2`, `ci-slave-4` and `transition-logs-1` machine types.
