### PR TITLE
Label `ci-slave-5` as having Postgres 9.3

### DIFF
--- a/hieradata/role.ci-slave.5.yaml
+++ b/hieradata/role.ci-slave.5.yaml
@@ -1,0 +1,2 @@
+---
+jenkins::slave::labels: '"mongodb-2.4 postgresql-9.3"'


### PR DESCRIPTION
This means we'll be able to tie builds that depend on Postgres 9.3 features to any slave with this label, rather than to a specific slave.

From `hieradata/role.ci-slave.yaml`, it appears that the MongoDB version is pinned, so we can safely have that label. I'm not so sure about the `rabbitmq` and `java6` labels, so I've left them out.

Ideally, these labels would be automatically generated from what's actually provisioned on the servers, but I figured that would be opening up a whole new can of devops.
