### PR TITLE
[#82935274] Simplify README by referring to deployment README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,9 @@
 - ...
 - Profit!
 
-## Setting up a real environment on remote machines
+## Provisioning a new environment or a new machine
 
-Provision blank Ubuntu 12.04 machines, possibly running [machine-bootstrap](https://github.com/alphagov/machine-bootstrap) to add some basic security to the machines.
+See the [ci-deployment][] repository [README][] for instructions.
 
-1. Run the bootstrap script from `tools/bootstrap` on each new machine.
-   It should be run as locally on those machines as `./bootstrap machinename.domainname`
-   The script:
-     - sets up apt sources and runs `apt-get update`
-     - installs ruby 1.9.3
-     - set up basic users to manage the environment (you will need to edit this if your user is not included)
-     - tell machines their names: hostname, dns  & etc hosts
-2. Run puppet on the machines (for GDS, this is done with Fabric from the [ci-deployment repository](https://github.gds/gds/ci-deployment))
-   - this packages up puppet and puppet code and runs on all the boxes
-   - you may need to edit the fabric code to ensure it runs on the correct ip ranges
-   - fabric can also deploy the ssl certs that are needed in prod
-3. Manual steps
-   - The manual steps are contained within the Ops Manual: https://github.gds/pages/gds/opsmanual/infrastructure/howto/configuring-ci-environment-and-machines.html
-4. Rolling out changes:
-   - Once you are happy that the puppet code is correct (follow _Development Workflow_ above), then
-     you can apply code changes to CI by running the fabric scripts described in Section 2 above.
+[ci-deployment]: https://github.gds/gds/ci-deployment
+[README]: https://github.gds/gds/ci-deployment/blob/master/README.md


### PR DESCRIPTION
**DEPENDS on ci-deployment#44**

Instructions on provisioning new machines and deploying Puppet belong in
the `ci-deployment` repository. Link to the README from that repo to
simplify the instructions.
