### PR TITLE
Disable automatic reboots.

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -10,7 +10,7 @@ classes:
   - locales
 
 apt::always_apt_update: true
-apt::unattended_upgrades::auto_reboot: true
+apt::unattended_upgrades::auto_reboot: false
 
 jenkins::lts: 1
 


### PR DESCRIPTION
The reboot this morning caused jenkins to come up with a blank config.
Disable this feature until we've diagnosed the cause.
