### PR TITLE
Replace goenv-go 1.4 with 1.4.1

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -46,9 +46,14 @@ class ci_environment::jenkins_job_support {
   class { 'goenv':
     global_version => '1.2.2',
   }
-  goenv::version { ['1.2.2', '1.3.1', '1.3.3', '1.4']: }
+  goenv::version { ['1.2.2', '1.3.1', '1.3.3', '1.4.1']: }
   package { ['golang-gom', 'godep']:
     ensure => latest,
+  }
+
+  # FIXME: remove once run everywhere.
+  package { 'goenv-go-1.4':
+    ensure => purged,
   }
 
   # Needed to notify github of build statuses


### PR DESCRIPTION
1.4 hasn't been used yet, so it makes sense to replace with 1.4.1, which
has just been released.