### PR TITLE
Add sphinx package for opsmanual builds

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -41,6 +41,7 @@ class ci_environment::jenkins_job_support {
     'libgif-dev', # alphagov/screenshot-as-a-service
     'cmake', # alphagov/spotlight
     'libffi-dev', # alphagov/backdrop
+    'python-sphinx', # gds/opsmanual
   ])
 
   class { 'goenv':


### PR DESCRIPTION
```
Build finished. The HTML pages are in _build/html.
+ git branch -f gh-pages origin/gh-pages
Branch gh-pages set up to track remote branch gh-pages from origin.
+ make pages
Makefile:12: *** The 'sphinx-build' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the 'sphinx-build' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/. Stop.
Build step 'Execute shell' marked build as failure
```
https://ci-new.alphagov.co.uk/job/opsmanual_build/10620/console

cc @mattbostock 