### PR TITLE
Upgrade RabbitMQ to 3.4.3-1

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -115,3 +115,4 @@ cdn_logs::cert: |
   -----END CERTIFICATE-----
 
 rabbitmq::delete_guest_user: true
+rabbitmq::package_ensure: '3.4.3-1'


### PR DESCRIPTION
To ensure parity with our preview, staging and production stacks, we should
run 3.4.3-1 in CI too to ensure that builds don't fail because of outdated
and mismatched versions.

This does that.