### PR TITLE
Restart rsyslog at five past the hour on transition-logs-1 via cron

### DIFF
--- a/modules/ci_environment/manifests/transition_logs.pp
+++ b/modules/ci_environment/manifests/transition_logs.pp
@@ -67,6 +67,15 @@ class ci_environment::transition_logs {
         require     => File["${logs_processor_home}/process_transition_logs.sh"]
     }
 
+    cron { 'restart_rsyslog':
+        ensure      => present,
+        environment => 'PATH=/usr/sbin:/usr/bin:/sbin:/bin',
+        command     => 'service rsyslog restart',
+        user        => root,
+        hour        => absent,
+        minute      => 5
+    }
+
     $accounts = hiera('ci_environment::transition_logs::rssh_users')
     ensure_packages([
         'rssh',


### PR DESCRIPTION
- There is an ongoing problem where Bouncer's CDN logs stop being
  received intermittently, requiring a restart of `rsyslog` which 99%
  of the time fixes the problem and logs come in again after a few
  minutes.
- This restart every hour at five past the hour is a temporary
  solution while we think of a better fix, or even fix the problem at
  source, to avoid people intermittently checking that things are
  still working every few hours during evenings or weekends.
- Tested this in dev and it appears to have worked:  
   `vagrant@transition-logs-1:~$ sudo tail /var/log/cron.log`  
   `Feb  2 07:05:01 transition-logs-1 CRON[32236]: (root) CMD (service rsyslog restart)`