### PR TITLE
Remove Gemfury API key

### DIFF
--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -16,7 +16,6 @@ ci_environment::jenkins_master::jenkins_serveraliases:
   - '172.16.11.10'
 
 ci_environment::jenkins_user::rubygems_api_key: 'a_rubygems_key'
-ci_environment::jenkins_user::gemfury_api_key: 'a_gemfury_key'
 
 ci_environment::jenkins_user::npm_auth: 'an_auth_token'
 ci_environment::jenkins_user::npm_email: 'an-email-address@gov.uk'

--- a/modules/ci_environment/manifests/jenkins_user.pp
+++ b/modules/ci_environment/manifests/jenkins_user.pp
@@ -9,7 +9,6 @@ class ci_environment::jenkins_user (
   $npm_auth,
   $npm_email,
   $rubygems_api_key,
-  $gemfury_api_key
 ) {
   validate_string($jenkins_home)
 
@@ -51,15 +50,6 @@ class ci_environment::jenkins_user (
     group   => 'jenkins',
     mode    => '0600',
     content => template('ci_environment/dotgem/credentials.erb'),
-    require => File['jenkins_dotgem_dir'],
-  }
-
-  file {"${jenkins_home}/.gem/gemfury":
-    ensure  => present,
-    owner   => 'jenkins',
-    group   => 'jenkins',
-    mode    => '0600',
-    content => template('ci_environment/dotgem/gemfury.erb'),
     require => File['jenkins_dotgem_dir'],
   }
 

--- a/modules/ci_environment/templates/dotgem/gemfury.erb
+++ b/modules/ci_environment/templates/dotgem/gemfury.erb
@@ -1,2 +1,0 @@
----
-:gemfury_api_key: <%= @gemfury_api_key %>


### PR DESCRIPTION
I don't think we publish anything to Gemfury any more, so there's no point in having an API key on the CI machines.