### PR TITLE
Add postgresql-9.3 label to ci-slave-3

### DIFF
--- a/hieradata/role.ci-slave.3.yaml
+++ b/hieradata/role.ci-slave.3.yaml
@@ -1,2 +1,2 @@
 ---
-jenkins::slave::labels: 'mongodb-2.4'
+jenkins::slave::labels: '"mongodb-2.4 postgresql-9.3"'


### PR DESCRIPTION
This is being [re-provisioned with trusty](https://github.gds/gds/ci-deployment/pull/47), and therefore will now have postgresql 9.3