### PR TITLE
Tweak test setup so that it'll work when we add some tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 # Ignore lock file to facilitate matrix builds.
 before_install: rm Gemfile.lock
+before_script: bundle exec librarian-puppet install
 rvm:
   - 1.9.3
   - ruby-head

--- a/Puppetfile
+++ b/Puppetfile
@@ -22,7 +22,7 @@ mod 'saz/dnsmasq',                 '1.0.1'
 
 mod 'alphagov/clamav',        :git => 'git://github.com/alphagov/puppet-clamav',
                               :ref => '31af4f0c2753dd25bca3dd0c7cc69d273c4d640d'
-mod 'alphagov/duplicity',     :git => 'git@github.com:alphagov/puppet-duplicity.git',
+mod 'alphagov/duplicity',     :git => 'git://github.com/alphagov/puppet-duplicity.git',
                               :ref => 'b9ea2e67ed1bb293fc3e13d4ba20ba3fc0f199f9'
 mod 'alphagov/ext4mount',     :git => 'git://github.com/alphagov/puppet-ext4mount.git'
 mod 'valentinroca/fail2ban',  :git => 'git://github.com/valentinroca/puppet-fail2ban',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -48,6 +48,13 @@ GIT
       puppetlabs-stdlib (>= 3.0.0)
 
 GIT
+  remote: git://github.com/alphagov/puppet-duplicity.git
+  ref: b9ea2e67ed1bb293fc3e13d4ba20ba3fc0f199f9
+  sha: b9ea2e67ed1bb293fc3e13d4ba20ba3fc0f199f9
+  specs:
+    alphagov-duplicity (0.0.1)
+
+GIT
   remote: git://github.com/alphagov/puppet-ext4mount.git
   ref: master
   sha: d97f99cc2801b83152b905d1285fa34e689cb499
@@ -140,13 +147,6 @@ GIT
   sha: 201ac7d0f30a118234a7f2edf4be4bd5c99954ce
   specs:
     valentinroca-fail2ban (1.1.0)
-
-GIT
-  remote: git@github.com:alphagov/puppet-duplicity.git
-  ref: b9ea2e67ed1bb293fc3e13d4ba20ba3fc0f199f9
-  sha: b9ea2e67ed1bb293fc3e13d4ba20ba3fc0f199f9
-  specs:
-    alphagov-duplicity (0.0.1)
 
 DEPENDENCIES
   alphagov-clamav (>= 0)

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -1,34 +1,8 @@
 require 'csv'
 require 'rspec-puppet'
 require 'puppet'
-require 'puppet/parser/functions/extlookup'
 
 HERE = File.expand_path(File.dirname(__FILE__))
-
-module MockExtdata
-  def update_extdata(h)
-    # FIXME: Currently update_extdata on each call overrides puppet extlookup
-    # function, which is inefficient. This should be removed once we move to
-    # hiera
-    Puppet::Parser::Functions.newfunction(:extlookup, :type => :rvalue) do |args|
-      extdata = {
-        'app_domain'    => 'test.gov.uk',
-        'website_root'  => 'www.test.gov.uk',
-        'http_username' => 'test_username',
-        'http_password' => 'test_password',
-        'internal_tld'  => 'test',
-
-        'google_client_id_datainsight'               => 'example client id',
-        'google_client_secret_datainsight'           => 'example client secret',
-        'google_analytics_refresh_token_datainsight' => 'example refresh token',
-        'google_drive_refresh_token_datainsight'     => 'example refresh token'
-      }.merge!(h)
-
-      key, default = args
-      extdata[key] || default or raise Puppet::ParseError, "No match found for '#{key}' in any data file during extlookup()"
-    end
-  end
-end
 
 RSpec.configure do |c|
   c.manifest    = File.join(HERE, 'manifests', 'site.pp')
@@ -36,16 +10,4 @@ RSpec.configure do |c|
     File.join(HERE, 'modules'),
     File.join(HERE, 'vendor', 'modules')
   ].join(':')
-  c.include MockExtdata
-
-  c.before do
-    # FIXME: We shouldn't need to do this. puppet/face should. See:
-    # - http://projects.puppetlabs.com/issues/15529
-    # - https://groups.google.com/forum/#!topic/puppet-dev/Yk0WC1JZCg8/discussion
-    if (Puppet::PUPPETVERSION.to_i >= 3 && !Puppet.settings.app_defaults_initialized?)
-      Puppet.initialize_settings
-    end
-
-    update_extdata({})
-  end
 end


### PR DESCRIPTION
The tests failed for [a branch I was working on](https://github.com/alphagov/ci-puppet/tree/elasticsearch_update) because travis wasn't doing a librarian-puppet install.

Additionally, there was still some setup for extdata which is no longer relevant, so I've cleaned that up as well.