### PR TITLE
Fix dependency in default elasticsearch service cleanup

### DIFF
--- a/modules/gds_elasticsearch/manifests/init.pp
+++ b/modules/gds_elasticsearch/manifests/init.pp
@@ -46,7 +46,7 @@ class gds_elasticsearch (
     onlyif      => '/usr/bin/test -f /etc/init.d/elasticsearch',
     command     => '/etc/init.d/elasticsearch stop && /bin/rm -f /etc/init.d/elasticsearch && /usr/sbin/update-rc.d elasticsearch remove',
     before      => Elasticsearch::Instance[$::fqdn],
-    require     => Class['elasticsearch'],
+    require     => Package['elasticsearch'],
   }
 
   # FIXME: Remove this once it's run everywhere


### PR DESCRIPTION
This needs to actually depend on the package, otherwise it can run
before the package changes things, and therefore miss the init script
the package creates.