### PR TITLE
Ensure augeas ruby library is installed.

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -2,6 +2,9 @@
 $machine_role = regsubst($::clientcert, '^(.*)-\d\..*$', '\1')
 $machine_id = regsubst($::clientcert, '^.*-(\d)\..*$', '\1')
 node default {
+  ensure_packages(['libaugeas-ruby'])
+  Package['libaugeas-ruby'] -> Augeas <| |>
+
   hiera_include('classes')
 }
 


### PR DESCRIPTION
This is needed for augeas to work.  This didn't show up in development
because the vagrant boxes in use ship with it already installed.