### PR TITLE
Disable travis build against ruby-head.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,4 @@
 language: ruby
-# Ignore lock file to facilitate matrix builds.
-before_install: rm Gemfile.lock
 before_script: bundle exec librarian-puppet install
 rvm:
   - 1.9.3
-  - ruby-head
-env:
-  - PUPPET_VERSION="~> 3.7.1"
-matrix:
-  allow_failures:
-    - rvm: ruby-head


### PR DESCRIPTION
Unlike a module, there seems little point to do a matrix build of a
whole puppet repo.  The build is also currently failing against
ruby-head.

Removing this means we no longer need to do any kind of matrix builds,
and can leave the Gemfile.lock alone.