### PR TITLE
Upgrade openjdk6 slaves to openjdk7.

### DIFF
--- a/hieradata/role.ci-slave.1.yaml
+++ b/hieradata/role.ci-slave.1.yaml
@@ -1,4 +1,2 @@
 ---
-jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 java6"'
-
-java::package: 'openjdk-6-jdk'
+jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4"'

--- a/hieradata/role.ci-slave.2.yaml
+++ b/hieradata/role.ci-slave.2.yaml
@@ -1,4 +1,2 @@
 ---
-jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 rabbitmq java6"'
-
-java::package: 'openjdk-6-jdk'
+jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 rabbitmq"'

--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -96,6 +96,16 @@ class ci_environment::jenkins_job_support {
     require => [Exec['set-licence-selected'], Exec['set-licence-seen']],
   }
 
+  # FIXME: remove once this has run everywhere.
+  package { [
+      'openjdk-6-jdk',
+      'openjsk-6-jre',
+      'openjdk-6-jre-headless',
+      'openjdk-6-jre-lib',
+    ]:
+      ensure => purged;
+  }
+
   include gds_elasticsearch
 
   class { 'redis':


### PR DESCRIPTION
We no longer have anything that depends on openjdk6.