### PR TITLE
Upgrade ci-slave-3 to elasticsearch 1.4

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -13,6 +13,7 @@ apt::always_apt_update: true
 apt::purge_sources_list_d: true
 apt::unattended_upgrades::auto_reboot: false
 
+# Version potentially overridden on individual ci-slave machines
 gds_elasticsearch::version: '0.90.12'
 gds_elasticsearch::number_of_replicas: 0
 

--- a/hieradata/role.ci-slave.3.yaml
+++ b/hieradata/role.ci-slave.3.yaml
@@ -1,2 +1,4 @@
 ---
-jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 postgresql-9.3"'
+jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 postgresql-9.3"'
+
+gds_elasticsearch::version: '1.4.2'

--- a/modules/gds_elasticsearch/manifests/init.pp
+++ b/modules/gds_elasticsearch/manifests/init.pp
@@ -88,6 +88,7 @@ class gds_elasticsearch (
     },
     datadir       => '/mnt/elasticsearch',
     init_defaults => {
+      'JAVA_HOME'    => '/usr/lib/jvm/default-java',
       'ES_HEAP_SIZE' => $heap_size,
     },
   }


### PR DESCRIPTION
This also includes a tweak to make elasticsearch use the java specified by the Ubuntu alternatives mechanism.  See 3899d7f for details.