### PR TITLE
Add a workaround for the oracle java tarball.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@
 - ...
 - Profit!
 
+### Oracle Java 7 "fun"
+
+The Oracle Java 7 installer needs to be preseeded with the oracle tarball. If
+jdk-7u9-linux-x64.tar.gz is present in the `vendor` folder, the vagrant
+bootstrap script will copy it into the necessary location before provisioning.
+
+Due to Oracle's licence terms we can't commit this tarball to this (public)
+repository, nor can we make it available at a download URL that we make public,
+so determining where to download this tarball from is left as an exercise for
+the reader.
+
 ## Provisioning a new environment or a new machine
 
 See the [ci-deployment][] repository [README][] for instructions.

--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -70,6 +70,10 @@ main() {
   if [ "$1" != "unset" ]; then
     fix_hostname $1
   fi
+  if [ -f /vagrant/vendor/jdk-7u9-linux-x64.tar.gz ]; then
+    mkdir -p /var/cache/oracle-jdk7-installer
+    cp /vagrant/vendor/jdk-7u9-linux-x64.tar.gz /var/cache/oracle-jdk7-installer
+  fi
 }
 
 if [ $# -eq 1 ]; then


### PR DESCRIPTION
This adds a convienience bootstrap hook to make it possible to provision
vagrant machines without errors due to the missing oracle java7 tarball.