### PR TITLE
Jenkins master needs Java too...

### DIFF
--- a/modules/ci_environment/manifests/jenkins_master.pp
+++ b/modules/ci_environment/manifests/jenkins_master.pp
@@ -17,11 +17,12 @@ class ci_environment::jenkins_master (
   validate_string($github_enterprise_cert, $jenkins_servername, $jenkins_home)
   validate_array($jenkins_serveraliases)
 
+  include java
   include jenkins
   include jenkins_user
   include jenkins_job_support
 
-  Class['jenkins'] -> Class['jenkins_user']
+  Class['java'] -> Class['jenkins'] -> Class['jenkins_user']
   Package <| title == 'jenkins' |> -> Jenkins::Plugin <| |>
 
   package {'ssl-cert':


### PR DESCRIPTION
This was only specified in ci_environment::jenkins_slave.  Previously it
had been included on the master by coincidence, or manually.  Now that
we've cleaned up openjdk6, that's no longer the case, so this will
ensure that java is installed correctly on the master.

This is currently causing Jenkins to be broken because it's running under Oracle java which uses a different keystore, and therefore doesn't have the github.gds cert loaded.