### PR TITLE
Re-enable elasticsearch dynamic scripting for 1.4

### DIFF
--- a/modules/gds_elasticsearch/manifests/init.pp
+++ b/modules/gds_elasticsearch/manifests/init.pp
@@ -49,26 +49,36 @@ class gds_elasticsearch (
     require     => Package['elasticsearch'],
   }
 
-  elasticsearch::instance { $::fqdn:
-    config        => {
-      'cluster.name'             => $cluster_name,
-      'index.number_of_replicas' => $number_of_replicas,
-      'index.number_of_shards'   => $number_of_shards,
-      'index.refresh_interval'   => $refresh_interval,
-      'transport.tcp.port'       => $transport_port,
-      'network.publish_host'     => $::fqdn,
-      'node.name'                => $::fqdn,
-      'http.port'                => $http_port,
-      'discovery'                => {
-        'zen' => {
-          'minimum_master_nodes' => $minimum_master_nodes,
-          'ping'                 => {
-            'multicast.enabled' => false,
-            'unicast.hosts'     => $cluster_hosts,
-          },
+  $instance_config = {
+    'cluster.name'             => $cluster_name,
+    'index.number_of_replicas' => $number_of_replicas,
+    'index.number_of_shards'   => $number_of_shards,
+    'index.refresh_interval'   => $refresh_interval,
+    'transport.tcp.port'       => $transport_port,
+    'network.publish_host'     => $::fqdn,
+    'node.name'                => $::fqdn,
+    'http.port'                => $http_port,
+    'discovery'                => {
+      'zen' => {
+        'minimum_master_nodes' => $minimum_master_nodes,
+        'ping'                 => {
+          'multicast.enabled' => false,
+          'unicast.hosts'     => $cluster_hosts,
         },
       },
     },
+  }
+
+  if versioncmp($version, '1.4.3') >= 0 {
+    # 1.4.3 introduced this setting and set it to false by default
+    # http://www.elastic.co/guide/en/elasticsearch/reference/1.x/modules-scripting.html
+    $instance_config_real = merge($instance_config, {'script.groovy.sandbox.enabled' => true})
+  } else {
+    $instance_config_real = $instance_config
+  }
+
+  elasticsearch::instance { $::fqdn:
+    config        => $instance_config_real,
     datadir       => '/mnt/elasticsearch',
     init_defaults => {
       'JAVA_HOME'    => '/usr/lib/jvm/default-java',

--- a/modules/gds_elasticsearch/spec/classes/gds_elasticsearch_spec.rb
+++ b/modules/gds_elasticsearch/spec/classes/gds_elasticsearch_spec.rb
@@ -2,6 +2,7 @@ require_relative '../../../../spec_helper'
 
 describe 'gds_elasticsearch', :type => :class do
   let(:facts) {{
+    :fqdn => 'test.example.com',
     :lsbdistid => 'ubuntu',
     :operatingsystem => 'Ubuntu',
     :kernel => 'Linux',
@@ -40,5 +41,30 @@ describe 'gds_elasticsearch', :type => :class do
     end
 
     it { should contain_class('elasticsearch').with_manage_repo(false) }
+  end
+
+  describe "enabling dynamic scripting" do
+    let(:params) {{}}
+
+    it "should not be added to 0.90" do
+      params[:version] = '0.90.3'
+
+      instance = subject.resource('elasticsearch::instance', facts[:fqdn])
+      expect(instance[:config]).not_to have_key('script.groovy.sandbox.enabled')
+    end
+
+    it "should not be added for 1.4.2" do
+      params[:version] = '1.4.2'
+
+      instance = subject.resource('elasticsearch::instance', facts[:fqdn])
+      expect(instance[:config]).not_to have_key('script.groovy.sandbox.enabled')
+    end
+
+    it "should be added for 1.4.3" do
+      params[:version] = '1.4.3'
+
+      instance = subject.resource('elasticsearch::instance', facts[:fqdn])
+      expect(instance[:config]['script.groovy.sandbox.enabled']).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
Version 1.4.3 introduced a change that means that groovy dynamic
scripting (the default language) was disabled by default[1].  Rummager
relies on dynamic scripting, so we need this to be re-enabled.

[1] http://www.elastic.co/guide/en/elasticsearch/reference/1.x/modules-scripting.html