### PR TITLE
Remove datainsight databases

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/mysql.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/mysql.pp
@@ -30,12 +30,14 @@ class ci_environment::jenkins_job_support::mysql {
       password => 'content_planner',
       require  => Class['::mysql::server'];
 
+    # FIXME: Remove once these databases are gone from CI machines
     [
       'datainsights_todays_activity_test',
       'datainsight_weekly_reach_test',
       'datainsights_format_success_test',
       'datainsight_insidegov_test',
     ]:
+      ensure   => 'absent',
       user     => 'datainsight',
       password => 'datainsight',
       require  => Class['::mysql::server'];


### PR DESCRIPTION
The tests for the datainsight applications are no longer run because the applications have been retired. Remove the relevant databases.