### PR TITLE
Add rbenv-ruby 2.2.2 to CI machines.

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -83,8 +83,11 @@ class ci_environment::base {
   rbenv::version { '2.2.1':
     bundler_version => '1.8.3'
   }
+  rbenv::version { '2.2.2':
+    bundler_version => '1.9.4',
+  }
   rbenv::alias { '2.2':
-    to_version => '2.2.1'
+    to_version => '2.2.2'
   }
 
   file { '/etc/sudoers.d/gds':


### PR DESCRIPTION
Includes fix for
https://www.ruby-lang.org/en/news/2015/04/13/ruby-openssl-hostname-matching-vulnerability/