### PR TITLE
Enable automatic reboots on CI slaves

### DIFF
--- a/hieradata/role.ci-slave.yaml
+++ b/hieradata/role.ci-slave.yaml
@@ -1,4 +1,6 @@
 ---
+apt::unattended_upgrades::auto_reboot: true
+
 classes:
  - git
  - ci_environment::jenkins_slave


### PR DESCRIPTION
Enables automatic reboots on CI slaves, which is useful for picking up and 
installing Apt updates. Reboots should occur overnight.