### PR TITLE
Remove Node.js conditional logic

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -112,21 +112,10 @@ class ci_environment::jenkins_job_support {
     max_memory => '256mb',
   }
 
-  if $::lsbdistcodename == 'precise' {
-    $nodejs_ensure = '0.10.32-1chl1~precise1'
-  } else {
-    $nodejs_ensure = 'latest'
-
-    # The official Ubuntu Trusty nodejs package doesn't include npm, so add that too
-    package { 'npm':
-      ensure => 'latest',
-    }
-  }
-
   # uglifier requires a JavaScript runtime
   # alphagov/spotlight requires a decent version of Node (0.10+) and grunt-cli
   package { 'nodejs':
-    ensure => $nodejs_ensure,
+    ensure => 'latest',
   }
   package { 'grunt-cli':
     ensure   => '0.1.9',


### PR DESCRIPTION
We've added Node.js 0.10.37 to the GOV.UK Launchpad PPA, which means we can run the same version of Node.js on Precise and Trusty. This package includes npm for both distributions, so the installation of npm on Trusty machines causes a failure.

/cc @alext @jamiecobbett 