### PR TITLE
Upgrade ci-slave-1 to elasticsearch 1.4

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ def vagrant_config(config, version)
     'ci-slave-2'  => {:ip => '172.16.11.12'},
     'ci-slave-3'  => {:ip => '172.16.11.13'},
     'ci-slave-4'  => {:ip => '172.16.11.14'},
+    'ci-slave-5'  => {:ip => '172.16.11.15'},
     'ci-management-1' => {:ip => '172.16.11.09'},
     'transition-logs-1' => {:ip => '172.16.11.20',
                             :extra_disks => [

--- a/hieradata/role.ci-slave.1.yaml
+++ b/hieradata/role.ci-slave.1.yaml
@@ -1,2 +1,4 @@
 ---
-jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4"'
+jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4"'
+
+gds_elasticsearch::version: '1.4.4'


### PR DESCRIPTION
Now that rummager is using elasticsearch 1.4, we're sometimes seeing
builds help up waiting for a slave with es 1.4.  This therefore adds a
second machine with es 1.4.

This also adds ci-slave-5 to the Vagrantfile so it can be tested as well.