### PR TITLE
CI has 8 CPUs, which means we need 8 DBs for EFG

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/mysql.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/mysql.pp
@@ -48,6 +48,10 @@ class ci_environment::jenkins_job_support::mysql {
       'efg_test2',
       'efg_test3',
       'efg_test4',
+      'efg_test5',
+      'efg_test6',
+      'efg_test7',
+      'efg_test8',
     ]:
       user     => 'efg',
       password => 'efg',


### PR DESCRIPTION
Stops errors like:

    Mysql2::Error: Access denied for user 'efg'@'localhost' to database 'efg_test8'