### PR TITLE
Remove James Stewart

### DIFF
--- a/hieradata/users.yaml
+++ b/hieradata/users.yaml
@@ -46,9 +46,6 @@ gds_accounts::accounts:
     jabley:
         comment: James Abley
         ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC2568vUQp+Fb7bmSML5OHn0N8gmOjQp9LSE/HPh+xybMiX6ql8JhxDhPGl2NZl2zVmhICLlhY9HcX4E1w2mHY2MgSsoE148QPomYmcjkIkcQxh6nFN4Ga++foTu6WPkUQJudah3ML/XNs/D+yMgxk8nkel6EvIqgbbswlTQp22FmqGfk9XzJqX0mfTrlggJlacYlw+Z4JT4NhoFX4EefSSX0c6qm7fipX2U7M3hJUXxsakj0jM5GOk9xrEVCRUgx5M8l3rS2DwF0W54RewAdq5J9KdnIQi5DOsbVJKnR1flpoaIVuRq1x/feZ4yqi53ctYX5MT8tb6CLc8zmuU7XyR
-    james:
-        comment: James Stewart
-        ssh_key: AAAAB3NzaC1yc2EAAAABIwAAAQEAqwZNyosGZJ4L5mU+jisfTMk+jU0rhhgfTLTRut6TQ/hvktRn5g70xSVZKUMLdxoxjxgYS+630TY3N9wimYzCuRJLLHM7Ieih+emM5SCrXeWLND2k2gxReTxIAv4qHHIEJLLTbywUMeKBBdHA7UXTDOI9j1k6bR6myQT60Iwh0bknL8tH3yLP/SWUcI82Lu6QNSnT3epEXjurKbdz1RvUW+bN1CFO9ARDnBZ001/MIOge2Q44RHWrGz/bvtD9guyXzK5s6HVQNzbApinUqvTby9gbuRtT0OBk6T01wAcXvmMLmp1+mKRmkrlBhTgW00xijeU3nH2eR+NeSrTrRDgWmQ==
     jamiec:
         comment: Jamie Cobbett
         ssh_key: AAAAB3NzaC1yc2EAAAADAQABAAABAQCocQlnao2aVxfTTz3LVI0DSezz8CiMl6Ewphky/D25+H9PbC9GiD95/kLw6+2AVaJ7eGS1xKCq5BKzfNT8hPSVKnIIkGgUf44BWFM3G1Y2GCQ3FDDVOTv0i7CJt3CZJ06oDkLyyXmt86J2kjQfFnSvzWKmI36OiGr7QFez61G7k+6SE/ZmDqZVeAs+qqmFG+X0HcRTsjt7/u38xWNqofNEJfRGfPnxo3Jemy0IKlp0a46Km57vHHsEpTe/iUQu9koA5mR5eyW2hoya/Y167DiloZS7Bh9Q6WE1GKwX+wj2v2PwgmbgxyqwbWoi60jzNggf/Wc3/6vX+Ie09j0aEqHD


### PR DESCRIPTION
James has moved into a management role and we should keep the pool of
people with root access to a minimum, so remove his access.