### PR TITLE
Add labels to slave machines for ubuntu release.

### DIFF
--- a/hieradata/role.ci-slave.1.yaml
+++ b/hieradata/role.ci-slave.1.yaml
@@ -1,4 +1,4 @@
 ---
-jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4"'
+jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 ubuntu-precise"'
 
 gds_elasticsearch::version: '1.4.4'

--- a/hieradata/role.ci-slave.2.yaml
+++ b/hieradata/role.ci-slave.2.yaml
@@ -1,2 +1,2 @@
 ---
-jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 rabbitmq"'
+jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 rabbitmq ubuntu-precise"'

--- a/hieradata/role.ci-slave.3.yaml
+++ b/hieradata/role.ci-slave.3.yaml
@@ -1,4 +1,4 @@
 ---
-jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 postgresql-9.3"'
+jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 postgresql-9.3 ubuntu-trusty"'
 
 gds_elasticsearch::version: '1.4.4'

--- a/hieradata/role.ci-slave.4.yaml
+++ b/hieradata/role.ci-slave.4.yaml
@@ -1,2 +1,2 @@
 ---
-jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 cdn-acceptance-test"'
+jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 cdn-acceptance-test ubuntu-precise"'

--- a/hieradata/role.ci-slave.5.yaml
+++ b/hieradata/role.ci-slave.5.yaml
@@ -1,2 +1,2 @@
 ---
-jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 postgresql-9.3"'
+jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 postgresql-9.3 ubuntu-trusty"'


### PR DESCRIPTION
We have some apps where the test suites don't work on both trusty and
precise (due to things like different libxml versions etc.). Adding
these labels will allow apps to be pinned to the relevant Ubuntu release
where necessary.