### PR TITLE
Move RabbitMQ from content store to publishing API.

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/rabbitmq.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/rabbitmq.pp
@@ -15,6 +15,8 @@ class ci_environment::jenkins_job_support::rabbitmq {
     'govuk_crawler_worker':
       password => 'govuk_crawler_worker',
       tags     => ['monitoring'];
+    'publishing_api':
+      password => 'publishing_api';
   }
 
   rabbitmq_user_permissions {
@@ -38,6 +40,10 @@ class ci_environment::jenkins_job_support::rabbitmq {
       configure_permission => '^govuk_crawler_worker.*',
       read_permission      => '^govuk_crawler_worker.*',
       write_permission     => '^govuk_crawler_worker.*';
+    'publishing_api@/':
+      configure_permission => '^amq\.gen.*$',
+      read_permission      => '^(amq\.gen.*|published_documents_test)$',
+      write_permission     => '^(amq\.gen.*|published_documents_test)$';
   }
 
   gds_rabbitmq::exchange {


### PR DESCRIPTION
This is being moved as part of https://github.com/alphagov/publishing-api/pull/49

The `content_store` permissions will need removing
once this has been deployed.