### PR TITLE
Pypi configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,8 @@ def vagrant_config(config, version)
     config.vm.box     = "puppetlabs/ubuntu-14.04-64-puppet"
   end
 
+  config.vm.box_version = '1.0.1'
+
   config.vm.provision :shell, :path => 'tools/bootstrap'
   config.vm.provision :puppet do |puppet|
     puppet.manifest_file  = "site.pp"

--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -27,6 +27,10 @@ ci_environment::jenkins_master::jenkins_serveraliases:
 ci_environment::jenkins_user::rubygems_api_key: 'a_rubygems_key'
 ci_environment::jenkins_user::gemfury_api_key: 'a_gemfury_key'
 
+ci_environment::jenkins_user::pypi_username: 'pp-developers'
+ci_environment::jenkins_user::pypi_test_password: ''
+ci_environment::jenkins_user::pypi_live_password: ''
+
 ci_environment::jenkins_user::npm_auth: 'an_auth_token'
 ci_environment::jenkins_user::npm_email: 'an-email-address@gov.uk'
 

--- a/modules/ci_environment/manifests/jenkins_user.pp
+++ b/modules/ci_environment/manifests/jenkins_user.pp
@@ -9,7 +9,10 @@ class ci_environment::jenkins_user (
   $npm_auth,
   $npm_email,
   $rubygems_api_key,
-  $gemfury_api_key
+  $gemfury_api_key,
+  $pypi_username,
+  $pypi_test_password,
+  $pypi_live_password
 ) {
   validate_string($jenkins_home)
 
@@ -52,6 +55,14 @@ class ci_environment::jenkins_user (
     mode    => '0600',
     content => template('ci_environment/dotgem/credentials.erb'),
     require => File['jenkins_dotgem_dir'],
+  }
+
+  file {"${jenkins_home}/.pypirc":
+    ensure  => present,
+    owner   => 'jenkins',
+    group   => 'jenkins',
+    mode    => '0600',
+    content => template('ci_environment/pypirc.erb'),
   }
 
   file {"${jenkins_home}/.gem/gemfury":

--- a/modules/ci_environment/templates/pypirc.erb
+++ b/modules/ci_environment/templates/pypirc.erb
@@ -1,0 +1,14 @@
+[distutils] # this tells distutils what package indexes you can push to
+index-servers =
+    pypi
+    pypitest
+
+[pypi]
+repository: https://pypi.python.org/pypi
+username: <%= @pypi_username %>
+password: <%= @pypi_live_password %>
+
+[pypitest]
+repository: https://testpypi.python.org/pypi
+username: <%= @pypi_username %>
+password: <%= @pypi_test_password %>


### PR DESCRIPTION
Add configuration as jenkins was failing to push to pypi due to absence of pypi configuration files.
Performance platform client is a library that needs to be pushed to pypi.

Add vm box version as the versions of puppet used on the box was newer than 3.8.1 - the latest version supported.