### PR TITLE
Upgrade most slaves to elasticsearch 1.4

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -14,7 +14,7 @@ apt::purge_sources_list_d: true
 apt::unattended_upgrades::auto_reboot: false
 
 # Version potentially overridden on individual ci-slave machines
-gds_elasticsearch::version: '0.90.12'
+gds_elasticsearch::version: '1.4.4'
 gds_elasticsearch::number_of_replicas: 0
 
 jenkins::lts: 1

--- a/hieradata/role.ci-slave.1.yaml
+++ b/hieradata/role.ci-slave.1.yaml
@@ -1,4 +1,2 @@
 ---
 jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 ubuntu-precise"'
-
-gds_elasticsearch::version: '1.4.4'

--- a/hieradata/role.ci-slave.2.yaml
+++ b/hieradata/role.ci-slave.2.yaml
@@ -1,2 +1,2 @@
 ---
-jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 rabbitmq ubuntu-precise"'
+jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 rabbitmq ubuntu-precise"'

--- a/hieradata/role.ci-slave.3.yaml
+++ b/hieradata/role.ci-slave.3.yaml
@@ -1,4 +1,2 @@
 ---
 jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 postgresql-9.3 ubuntu-trusty"'
-
-gds_elasticsearch::version: '1.4.4'

--- a/hieradata/role.ci-slave.4.yaml
+++ b/hieradata/role.ci-slave.4.yaml
@@ -1,2 +1,2 @@
 ---
-jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 cdn-acceptance-test ubuntu-precise"'
+jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 cdn-acceptance-test ubuntu-precise"'

--- a/hieradata/role.ci-slave.5.yaml
+++ b/hieradata/role.ci-slave.5.yaml
@@ -1,2 +1,4 @@
 ---
 jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 postgresql-9.3 ubuntu-trusty"'
+
+gds_elasticsearch::version: '0.90.12'


### PR DESCRIPTION
Most apps use 1.4 now, so it makes sense for most CI servers to also use
it. This changes the default version to 1.4.4, but leaves ci-slave-5
running 0.90