### PR TITLE
Automate adding of distribution label to Jenkins slaves.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,6 @@ gem 'puppet-syntax'
 gem 'puppet-lint', '~> 0.3.0'
 gem 'rspec-puppet', '~> 0.1.0'
 gem 'puppetlabs_spec_helper', '~> 0.4.0'
+gem 'hiera-puppet-helper', :git => 'git://github.com/bobtfish/hiera-puppet-helper.git'
 gem "parallel_tests", "~> 0.16.10"
 gem "parallel", "~> 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: git://github.com/bobtfish/hiera-puppet-helper.git
+  revision: 155f132c0b225db4ff64db49f17d6c5bf354b871
+  specs:
+    hiera-puppet-helper (2.0.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -81,6 +87,7 @@ PLATFORMS
 
 DEPENDENCIES
   facter (= 2.2.0)
+  hiera-puppet-helper!
   librarian-puppet (~> 2.0)
   parallel (~> 1.0.0)
   parallel_tests (~> 0.16.10)

--- a/hieradata/role.ci-slave.1.yaml
+++ b/hieradata/role.ci-slave.1.yaml
@@ -1,2 +1,4 @@
 ---
-jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 ubuntu-precise"'
+ci_environment::jenkins_slave::labels:
+  - 'elasticsearch-1.4'
+  - 'mongodb-2.4'

--- a/hieradata/role.ci-slave.2.yaml
+++ b/hieradata/role.ci-slave.2.yaml
@@ -1,2 +1,5 @@
 ---
-jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 rabbitmq ubuntu-precise"'
+ci_environment::jenkins_slave::labels:
+  - 'elasticsearch-1.4'
+  - 'mongodb-2.4'
+  - 'rabbitmq'

--- a/hieradata/role.ci-slave.3.yaml
+++ b/hieradata/role.ci-slave.3.yaml
@@ -1,2 +1,5 @@
 ---
-jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 postgresql-9.3 ubuntu-trusty"'
+ci_environment::jenkins_slave::labels:
+  - 'elasticsearch-1.4'
+  - 'mongodb-2.4'
+  - 'postgresql-9.3'

--- a/hieradata/role.ci-slave.4.yaml
+++ b/hieradata/role.ci-slave.4.yaml
@@ -1,2 +1,5 @@
 ---
-jenkins::slave::labels: '"elasticsearch-1.4 mongodb-2.4 cdn-acceptance-test ubuntu-precise"'
+ci_environment::jenkins_slave::labels:
+  - 'elasticsearch-1.4'
+  - 'mongodb-2.4'
+  - 'cdn-acceptance-test'

--- a/hieradata/role.ci-slave.5.yaml
+++ b/hieradata/role.ci-slave.5.yaml
@@ -1,4 +1,7 @@
 ---
-jenkins::slave::labels: '"elasticsearch-0.90 mongodb-2.4 postgresql-9.3 ubuntu-trusty"'
+ci_environment::jenkins_slave::labels:
+  - 'elasticsearch-0.90'
+  - 'mongodb-2.4'
+  - 'postgresql-9.3'
 
 gds_elasticsearch::version: '0.90.12'

--- a/modules/ci_environment/manifests/jenkins_slave.pp
+++ b/modules/ci_environment/manifests/jenkins_slave.pp
@@ -6,10 +6,17 @@
 #
 class ci_environment::jenkins_slave (
   $jenkins_home,
+  $labels = []
 ) {
+  validate_array($labels)
 
   include java
-  include jenkins::slave
+
+  $labels_with_distribution = concat($labels, [downcase("${::lsbdistid}-${::lsbdistcodename}")])
+  class { 'jenkins::slave':
+    labels => sprintf('\'%s\'', join($labels_with_distribution, ' ')),
+  }
+
   include jenkins_job_support
 
   class {'github_gds_cert':

--- a/modules/ci_environment/spec/jenkins_slave_spec.rb
+++ b/modules/ci_environment/spec/jenkins_slave_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../../../spec_helper'
+
+describe 'ci_environment::jenkins_slave', :type => :class do
+  let(:facts) {{
+    :concat_basedir => '/tmp',
+    :fqdn => 'test.example.com',
+    :lsbdistid => 'Ubuntu',
+    :lsbdistcodename => 'trusty',
+    :operatingsystem => 'Ubuntu',
+    :operatingsystemrelease => '14.04',
+    :osfamily => 'Debian',
+    :kernel => 'Linux',
+  }}
+  let(:hiera_data) {{
+    'ci_environment::jenkins_user::rubygems_api_key' => 'a_rubygems_key',
+    'ci_environment::jenkins_user::gemfury_api_key' => 'a_gemfury_key',
+    'ci_environment::jenkins_user::pypi_username' => 'pp-developers',
+    'ci_environment::jenkins_user::pypi_test_password' => '',
+    'ci_environment::jenkins_user::pypi_live_password' => '',
+    'ci_environment::jenkins_user::npm_auth' => 'an_auth_token',
+    'ci_environment::jenkins_user::npm_email' => 'me@example.com',
+    'gds_elasticsearch::version' => '1.4.4',
+  }}
+
+  describe "setting jenkins labels" do
+    let(:params) {{
+      "jenkins_home" => "/tmp",
+    }}
+
+    it "sets includes the distribution label by default" do
+      expect(subject).to contain_class("jenkins::slave").
+        with_labels("'ubuntu-trusty'")
+    end
+
+    it "sets adds the given labels to the distribution label" do
+      params["labels"] = ["foo", "bar"]
+      expect(subject).to contain_class("jenkins::slave").
+        with_labels("'foo bar ubuntu-trusty'")
+    end
+
+    it "errors if not given an array" do
+      params["labels"] = "foo"
+      expect {subject}.to raise_error(Puppet::Error, /is not an Array/)
+    end
+  end
+end

--- a/spec_helper.rb
+++ b/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'csv'
 require 'rspec-puppet'
 require 'puppet'
+require 'hiera-puppet-helper'
 
 HERE = File.expand_path(File.dirname(__FILE__))
 


### PR DESCRIPTION
Instead of manually having to specify it in hiera, this can be derived
from the available facts.

This will make the process of upgrading these slaves to trusty simpler.