### PR TITLE
Add postgresql-9.3 label to upgraded slaves.

### DIFF
--- a/hieradata/role.ci-slave.1.yaml
+++ b/hieradata/role.ci-slave.1.yaml
@@ -2,3 +2,4 @@
 ci_environment::jenkins_slave::labels:
   - 'elasticsearch-1.4'
   - 'mongodb-2.4'
+  - 'postgresql-9.3'

--- a/hieradata/role.ci-slave.4.yaml
+++ b/hieradata/role.ci-slave.4.yaml
@@ -2,4 +2,5 @@
 ci_environment::jenkins_slave::labels:
   - 'elasticsearch-1.4'
   - 'mongodb-2.4'
+  - 'postgresql-9.3'
   - 'cdn-acceptance-test'


### PR DESCRIPTION
Now that ci-slave-{1,4} are on trusty they're running postgresql 9.3.
Update the labels to reflect this.