### PR TITLE
Remove aspell from jenkins environments

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -22,7 +22,6 @@ class ci_environment::jenkins_job_support {
     'dictionaries-common', # Needed by signon
     'wbritish-small', # Needed by signon
     'sqlite3', # Needed by gds-sso
-    'aspell', 'aspell-en', 'libaspell-dev', # Needed by rummager
     'libqtwebkit-dev', # Needed by capybara-webkit (Publisher)
     'bzr', # needed by some Go builds
     'mercurial', # needed by some Go builds


### PR DESCRIPTION
`aspell` used to be needed by rummager, but isn't needed any more.  This
got left behind when we removed it everywhere else.