### PR TITLE
Allow private org members on Github to use CI

### DIFF
--- a/hieradata/role.ci-master.yaml
+++ b/hieradata/role.ci-master.yaml
@@ -82,6 +82,6 @@ jenkins::plugin_hash:
     build-pipeline-plugin:
         version: "1.3.3"
     github-oauth:
-        version: "0.14"
+        version: "0.22"
     rebuild:
         version: "1.22"


### PR DESCRIPTION
Our CI Jenkins uses GitHub enterprise to authenticate users. This doesn't work
if your membership of the GDS organisation isn't public.

Version 0.22 adds support for these users.

See:
https://issues.jenkins-ci.org/browse/JENKINS-20845

https://github.com/jenkinsci/github-oauth-plugin/pull/48