### PR TITLE
Install extra packages on CI so that MapIt builds

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -34,6 +34,10 @@ class ci_environment::jenkins_job_support {
     'libgif-dev', # alphagov/screenshot-as-a-service
     'cmake', # alphagov/spotlight
     'libffi-dev', # alphagov/backdrop
+    'binutils', # alphagov/mapit
+    'libproj-dev', # alphagov/mapit
+    'gdal-bin', # alphagov/mapit
+    'libgdal-dev', # alphagov/mapit
   ])
 
   # libv8 development headers.  Needed by some gems (eg therubyracer)


### PR DESCRIPTION
- We're setting up CI builds of our new fork of MapIt, and they were
  failing to install packages if we didn't have these extra packages for
  geospatial Django, as per what we had to do to get MapIt running on
  the new Trusty machines:
  https://github.gds/gds/puppet/commit/03a5d4f50024c442128fe01a8b8135a80efa7f40.