### PR TITLE
Fix dnsmasq reloading.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -18,7 +18,7 @@ mod 'puppetlabs/rabbitmq',
   :git => 'git://github.com/alphagov/puppetlabs-rabbitmq.git',
   :ref => 'strip-backslashes'
 mod 'puppetlabs/stdlib',           '~> 4.0'
-mod 'saz/dnsmasq',                 '1.0.1'
+mod 'saz/dnsmasq',                 '1.1.0'
 
 mod 'alphagov/clamav',        :git => 'git://github.com/alphagov/puppet-clamav',
                               :ref => '31af4f0c2753dd25bca3dd0c7cc69d273c4d640d'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -35,7 +35,8 @@ FORGE
       puppetlabs-firewall (>= 0.0.4)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
     puppetlabs-stdlib (4.1.0)
-    saz-dnsmasq (1.0.1)
+    saz-dnsmasq (1.1.0)
+      puppetlabs-stdlib (>= 2.0.0)
     torrancew-account (0.0.5)
 
 GIT
@@ -176,6 +177,6 @@ DEPENDENCIES
   puppetlabs-postgresql (>= 0)
   puppetlabs-rabbitmq (>= 0)
   puppetlabs-stdlib (~> 4.0)
-  saz-dnsmasq (= 1.0.1)
+  saz-dnsmasq (= 1.1.0)
   valentinroca-fail2ban (>= 0)
 


### PR DESCRIPTION
For versions of dnsmasq prior to 1.1.0, notifying the base dnsmasq class
(which our dns modules does) didn't do the right thing. This has been
fixed in 1.1.0 by https://github.com/saz/puppet-dnsmasq/pull/4