### PR TITLE
Fix dnsmasq.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -18,7 +18,7 @@ mod 'puppetlabs/rabbitmq',
   :git => 'git://github.com/alphagov/puppetlabs-rabbitmq.git',
   :ref => 'strip-backslashes'
 mod 'puppetlabs/stdlib',           '~> 4.0'
-mod 'saz/dnsmasq',                 '1.1.0'
+mod 'saz/dnsmasq',                 '1.2.0'
 
 mod 'alphagov/clamav',        :git => 'git://github.com/alphagov/puppet-clamav',
                               :ref => '31af4f0c2753dd25bca3dd0c7cc69d273c4d640d'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -35,7 +35,7 @@ FORGE
       puppetlabs-firewall (>= 0.0.4)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
     puppetlabs-stdlib (4.1.0)
-    saz-dnsmasq (1.1.0)
+    saz-dnsmasq (1.2.0)
       puppetlabs-stdlib (>= 2.0.0)
     torrancew-account (0.0.5)
 
@@ -177,6 +177,6 @@ DEPENDENCIES
   puppetlabs-postgresql (>= 0)
   puppetlabs-rabbitmq (>= 0)
   puppetlabs-stdlib (~> 4.0)
-  saz-dnsmasq (= 1.1.0)
+  saz-dnsmasq (= 1.2.0)
   valentinroca-fail2ban (>= 0)
 


### PR DESCRIPTION
Version 1.1.0 has an undocumented dependency on the DavidSchmitt/common
module. This is fixed by https://github.com/saz/puppet-dnsmasq/pull/12
which removes this dependency.

This upgrades the module to 1.2.0 which includes this fix.