### PR TITLE
Replace our deprecated nginx module with supported one.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,8 +7,9 @@ mod 'elasticsearch/elasticsearch', '0.4.0'
 mod 'gdsoperations/goenv',         '0.0.4'
 mod 'gdsoperations/openconnect'
 mod 'gdsoperations/rbenv',         '1.2.0'
+mod 'jfryman/nginx',               '0.2.7'
 mod 'pdxcat/collectd',             '~> 0.0'
-mod 'puppetlabs/apt',              '~> 1.7.0'
+mod 'puppetlabs/apt',              '~> 1.7'
 mod 'puppetlabs/git',              '0.0.2'
 mod 'puppetlabs/java'
 mod 'puppetlabs/lvm',              '0.3.3'
@@ -38,9 +39,5 @@ mod 'alphagov/jenkins',       :git => 'git://github.com/alphagov/puppet-jenkins.
                               :ref => 'ca40459bea5a9dc91e12e8014c9878fcd2856ee7'
 mod 'alphagov/mongodb',       :git => 'git://github.com/alphagov/puppetlabs-mongodb.git',
                               :ref => 'dc077a209efdf8d80fac40d40fec575b6a0949d2'
-mod 'alphagov/nginx',         :git => 'git://github.com/alphagov/puppet-nginx.git',
-                              :ref => '1a87dd9fb29f5f137e3d4ee42ddcf45c9054700e'
 mod 'alphagov/rsyslog',       :git => 'git://github.com/alphagov/puppet-rsyslog.git',
                               :ref => 'acf2755cda80e2ecd107ed8de4d275c383db0487'
-mod 'alphagov/ssl',           :git => 'git://github.com/alphagov/puppet-ssl.git',
-                              :ref => '23bbb5ab57f26269acce3d4b43e643781747a551'

--- a/Puppetfile
+++ b/Puppetfile
@@ -11,6 +11,7 @@ mod 'pdxcat/collectd',             '~> 0.0'
 mod 'puppetlabs/apt',              '~> 1.7.0'
 mod 'puppetlabs/git',              '0.0.2'
 mod 'puppetlabs/java'
+mod 'puppetlabs/lvm',              '0.3.3'
 mod 'puppetlabs/mysql',            '0.9.0'
 mod 'puppetlabs/nodejs',           '0.4.0'
 mod 'puppetlabs/postgresql'
@@ -35,7 +36,6 @@ mod 'alphagov/harden',        :git => 'git://github.com/alphagov/puppet-harden.g
                               :ref => '5b27ee25e19f0c5421665246b76a13def8058e1c'
 mod 'alphagov/jenkins',       :git => 'git://github.com/alphagov/puppet-jenkins.git',
                               :ref => 'ca40459bea5a9dc91e12e8014c9878fcd2856ee7'
-mod 'puppetlabs/lvm',         :git => 'git://github.com/puppetlabs/puppetlabs-lvm.git'
 mod 'alphagov/mongodb',       :git => 'git://github.com/alphagov/puppetlabs-mongodb.git',
                               :ref => 'dc077a209efdf8d80fac40d40fec575b6a0949d2'
 mod 'alphagov/nginx',         :git => 'git://github.com/alphagov/puppet-nginx.git',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -13,13 +13,17 @@ FORGE
     gdsoperations-openconnect (1.0.0)
       puppetlabs-stdlib (>= 3.0.0)
     gdsoperations-rbenv (1.2.0)
+    jfryman-nginx (0.2.7)
+      puppetlabs-apt (< 3.0.0, >= 1.8.0)
+      puppetlabs-concat (< 2.0.0, >= 1.1.1)
+      puppetlabs-stdlib (< 5.0.0, >= 4.2.0)
     nanliu-staging (0.4.1)
     pdxcat-collectd (0.0.3)
       puppetlabs-stdlib (>= 2.0.0)
-    puppetlabs-apt (1.7.0)
+    puppetlabs-apt (1.8.0)
       puppetlabs-stdlib (>= 2.2.1)
-    puppetlabs-concat (1.1.0)
-      puppetlabs-stdlib (>= 4.0.0)
+    puppetlabs-concat (1.2.4)
+      puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
     puppetlabs-firewall (1.1.3)
     puppetlabs-git (0.0.2)
     puppetlabs-java (1.2.0)
@@ -36,7 +40,7 @@ FORGE
       puppetlabs-concat (< 2.0.0, >= 1.0.0)
       puppetlabs-firewall (>= 0.0.4)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
-    puppetlabs-stdlib (4.1.0)
+    puppetlabs-stdlib (4.9.0)
     saz-dnsmasq (1.2.0)
       puppetlabs-stdlib (>= 2.0.0)
     torrancew-account (0.0.5)
@@ -89,25 +93,11 @@ GIT
       puppetlabs-stdlib (>= 2.0.0)
 
 GIT
-  remote: git://github.com/alphagov/puppet-nginx.git
-  ref: 1a87dd9fb29f5f137e3d4ee42ddcf45c9054700e
-  sha: 1a87dd9fb29f5f137e3d4ee42ddcf45c9054700e
-  specs:
-    alphagov-nginx (0.0.1)
-
-GIT
   remote: git://github.com/alphagov/puppet-rsyslog.git
   ref: acf2755cda80e2ecd107ed8de4d275c383db0487
   sha: acf2755cda80e2ecd107ed8de4d275c383db0487
   specs:
     alphagov-rsyslog (2.0.1)
-
-GIT
-  remote: git://github.com/alphagov/puppet-ssl.git
-  ref: 23bbb5ab57f26269acce3d4b43e643781747a551
-  sha: 23bbb5ab57f26269acce3d4b43e643781747a551
-  specs:
-    alphagov-ssl (0.0.1)
 
 GIT
   remote: git://github.com/alphagov/puppetlabs-mongodb.git
@@ -150,9 +140,7 @@ DEPENDENCIES
   alphagov-harden (>= 0)
   alphagov-jenkins (>= 0)
   alphagov-mongodb (>= 0)
-  alphagov-nginx (>= 0)
   alphagov-rsyslog (>= 0)
-  alphagov-ssl (>= 0)
   attachmentgenie-locales (= 1.0.2)
   attachmentgenie-ssh (= 1.2.1)
   attachmentgenie-ufw (= 1.1.0)
@@ -161,8 +149,9 @@ DEPENDENCIES
   gdsoperations-goenv (= 0.0.4)
   gdsoperations-openconnect (>= 0)
   gdsoperations-rbenv (= 1.2.0)
+  jfryman-nginx (= 0.2.7)
   pdxcat-collectd (~> 0.0)
-  puppetlabs-apt (~> 1.7.0)
+  puppetlabs-apt (~> 1.7)
   puppetlabs-git (= 0.0.2)
   puppetlabs-java (>= 0)
   puppetlabs-lvm (= 0.3.3)

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -24,6 +24,8 @@ FORGE
     puppetlabs-git (0.0.2)
     puppetlabs-java (1.2.0)
       puppetlabs-stdlib (>= 2.4.0)
+    puppetlabs-lvm (0.3.3)
+      puppetlabs-stdlib (>= 4.1.0)
     puppetlabs-mysql (0.9.0)
       puppetlabs-stdlib (>= 2.2.1)
     puppetlabs-nodejs (0.4.0)
@@ -134,14 +136,6 @@ GIT
       puppetlabs-stdlib (>= 2.5)
 
 GIT
-  remote: git://github.com/puppetlabs/puppetlabs-lvm.git
-  ref: master
-  sha: b27bccecca2b9d527578c933221ffe361c6dce87
-  specs:
-    puppetlabs-lvm (0.3.1)
-      puppetlabs-stdlib (~> 4.1.0)
-
-GIT
   remote: git://github.com/valentinroca/puppet-fail2ban
   ref: 201ac7d0f30a118234a7f2edf4be4bd5c99954ce
   sha: 201ac7d0f30a118234a7f2edf4be4bd5c99954ce
@@ -171,7 +165,7 @@ DEPENDENCIES
   puppetlabs-apt (~> 1.7.0)
   puppetlabs-git (= 0.0.2)
   puppetlabs-java (>= 0)
-  puppetlabs-lvm (>= 0)
+  puppetlabs-lvm (= 0.3.3)
   puppetlabs-mysql (= 0.9.0)
   puppetlabs-nodejs (= 0.4.0)
   puppetlabs-postgresql (>= 0)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -56,10 +56,6 @@ ci_environment::jenkins_master::github_enterprise_cert: |
     LWIWJn/KXkog8bU776IixxWlO8l1TwiCUoDS9YsLIKIRCT74QE48qA==
     -----END CERTIFICATE-----
 
-ssl::params::ssl_path: '/etc/ssl'
-ssl::params::ssl_cert_file: 'certs/ssl-cert-snakeoil.pem'
-ssl::params::ssl_key_file: 'private/ssl-cert-snakeoil.key'
-
 # Self signed. For transition-logs development.
 cdn_logs::key: |
   -----BEGIN RSA PRIVATE KEY-----
@@ -118,6 +114,9 @@ cdn_logs::cert: |
   ywj3Z5o8PdM49oUR1rmQt2eQPRvMo8Rzh6xqNaV54t3dslOfL2Hre+dS63U/8cvu
   OmQVTqKNteZopB3dwsc4la9Y5PMCJ8OlJcm5BrV4A8mD
   -----END CERTIFICATE-----
+
+nginx::config::confd_purge: true
+nginx::config::vhost_purge: true
 
 rabbitmq::delete_guest_user: true
 rabbitmq::package_ensure: '3.4.3-1'

--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -6,7 +6,7 @@ apt::sources:
   'puppetlabs':
     location: 'http://apt.puppetlabs.com'
     repos: 'main dependencies'
-    key: '4BD6EC30'
+    key: '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30'
 
 jenkins::slave::broadcast_address: 172.16.11.255
 

--- a/modules/ci_environment/manifests/graphite_server.pp
+++ b/modules/ci_environment/manifests/graphite_server.pp
@@ -2,20 +2,29 @@
 #
 # Supporting configuration for the graphite server
 #
-class ci_environment::graphite_server {
+# === Parameters
+#
+# [*ssl_cert*]
+# [*ssl_key*]
+#   Absolute path to the ssl cert and key for the nginx vhost to use.
+#
+class ci_environment::graphite_server (
+  $ssl_cert = '/etc/ssl/certs/ssl-cert-snakeoil.pem',
+  $ssl_key = '/etc/ssl/private/ssl-cert-snakeoil.key',
+) {
   include graphite
 
-  package {'ssl-cert':
-    ensure  => latest,
-  }
+  include nginx
 
-  class {'nginx::server':
-    require => Package['ssl-cert'],
-  }
-
-  nginx::vhost::proxy  {'graphite-nginx':
-    ssl            => true,
-    isdefaultvhost => true,
-    upstream_port  => 8000,
+  nginx::resource::vhost { 'graphite-nginx':
+    listen_options   => 'default',
+    proxy            => 'http://localhost:8000/',
+    proxy_set_header => $::nginx::config::proxy_set_header, # Necessary until https://github.com/jfryman/puppet-nginx/pull/700 is released
+    ssl              => true,
+    rewrite_to_https => true,
+    ssl_cert         => $ssl_cert,
+    ssl_key          => $ssl_key,
+    index_files      => [],
+    add_header       => {'Strict-Transport-Security' => '"max-age=31536000"'},
   }
 }

--- a/modules/ci_environment/manifests/jenkins_master.pp
+++ b/modules/ci_environment/manifests/jenkins_master.pp
@@ -7,10 +7,18 @@
 # https://github.gds/pages/gds/opsmanual \
 #   /infrastructure/howto/configuring-ci-environment-and-machines.html
 #
+# === Parameters
+#
+# [*ssl_cert*]
+# [*ssl_key*]
+#   Absolute path to the ssl cert and key for the nginx vhost to use.
+#
 class ci_environment::jenkins_master (
   $github_enterprise_cert,
   $jenkins_servername,
   $jenkins_serveraliases = [],
+  $ssl_cert = '/etc/ssl/certs/ssl-cert-snakeoil.pem',
+  $ssl_key = '/etc/ssl/private/ssl-cert-snakeoil.key',
   $slave_user = 'slave',
   $jenkins_home
 ) {
@@ -25,21 +33,19 @@ class ci_environment::jenkins_master (
   Class['java'] -> Class['jenkins'] -> Class['jenkins_user']
   Package <| title == 'jenkins' |> -> Jenkins::Plugin <| |>
 
-  package {'ssl-cert':
-    ensure  => '1.0.28ubuntu0.1',
-  }
+  include nginx
 
-  class {'nginx::server':
-    require => Package['ssl-cert'],
-  }
-
-  nginx::vhost::proxy  { 'jenkins-nginx':
-    ssl            => true,
-    ssl_redirect   => true,
-    isdefaultvhost => true,
-    servername     => $jenkins_servername,
-    serveraliases  => $jenkins_serveraliases,
-    magic          => 'add_header Strict-Transport-Security "max-age=31536000";'
+  nginx::resource::vhost { $jenkins_servername:
+    server_name      => flatten([$jenkins_servername, $jenkins_serveraliases]),
+    listen_options   => 'default',
+    proxy            => 'http://localhost:8080/',
+    proxy_set_header => $::nginx::config::proxy_set_header, # Necessary until https://github.com/jfryman/puppet-nginx/pull/700 is released
+    ssl              => true,
+    rewrite_to_https => true,
+    ssl_cert         => $ssl_cert,
+    ssl_key          => $ssl_key,
+    index_files      => [],
+    add_header       => {'Strict-Transport-Security' => '"max-age=31536000"'},
   }
 
   file {'/etc/ssl/certs/github.gds.pem':

--- a/modules/gds_elasticsearch/manifests/repo.pp
+++ b/modules/gds_elasticsearch/manifests/repo.pp
@@ -15,7 +15,7 @@ class gds_elasticsearch::repo(
     location     => "http://apt.production.alphagov.co.uk/elasticsearch-${repo_version}",
     release      => 'stable',
     architecture => $::architecture,
-    key          => '37E3ACBB',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
     include_src  => false,
   }
 }

--- a/modules/gds_rabbitmq/manifests/repo.pp
+++ b/modules/gds_rabbitmq/manifests/repo.pp
@@ -4,7 +4,7 @@ class gds_rabbitmq::repo {
     location     => 'http://apt.production.alphagov.co.uk/rabbitmq',
     release      => 'testing',
     architecture => $::architecture,
-    key          => '37E3ACBB',
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
     include_src  => false,
   }
 


### PR DESCRIPTION
this replaces the deprecated alphagov/nginx module that's no longer
maintained with jfryman/nginx, which is the most widely used one on the
forge.

The nginx configs for the various vhosts changes quite a bit with this new module, but should be functionally equivelent (I've tested as far as possible in vagrant). One significant change is that this drop SSLv3 from the list of allowed protocols, which is a good thing.

This will require some updates to ci-deployment (to change how the paths to SSL certs are specified).