### PR TITLE
Revert "Remove ruby 2.0.0 everywhere."

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -54,6 +54,13 @@ class ci_environment::base {
     to_version => '1.9.3-p550',
   }
 
+  rbenv::version { '2.0.0-p353':
+    bundler_version => '1.6.5'
+  }
+  rbenv::alias { '2.0.0':
+    to_version => '2.0.0-p353',
+  }
+
   rbenv::version { '2.1.2':
     bundler_version => '1.6.5',
   }


### PR DESCRIPTION
This reverts commit de97578cab18816a9cd1aeba10e796cf10eb0649.

Ruby 2.0.0 is still supported by vCloud Tools [1] [2] and we want to run
our integration tests with the oldest version we support as it's most
likely to catch any breaking changes.

[1]: https://github.com/gds-operations/vcloud-edge_gateway/blob/d3a9f3ad94fad2c07cc497c97855a540835fd8b5/rbenv_version.sh#L1
[2]: https://github.com/gds-operations/vcloud-edge_gateway/blob/d3a9f3ad94fad2c07cc497c97855a540835fd8b5/.travis.yml#L4