### PR TITLE
Use our apt repo for Jenkins installs.

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -13,49 +13,6 @@ apt::always_apt_update: true
 apt::purge_sources_list_d: true
 apt::unattended_upgrades::auto_reboot: false
 
-# Version potentially overridden on individual ci-slave machines
-gds_elasticsearch::version: '1.4.4'
-gds_elasticsearch::number_of_replicas: 0
-
-jenkins::lts: 1
-
-locales::default_value: en_GB.UTF-8
-locales::available:
-  - "en_GB.UTF-8 UTF-8"
-
-ci_environment::github_sshkeys::github_dotcom_key: 'AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
-
-ci_environment::github_sshkeys::github_dotgds_key: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDJsR5gu4+LPnomBEO37hY0l1chnD6U3eA1EHUg/o5op95dal49ZEvVEGtDCWyzwb2AF82/+APwCEHmAGF9l0suG5mU/VvtH4ne+S1Kji0TY+67t5rDDmckC0hqSkBxBrDyHROkXtRIyc/dyyuRhQBgW6zY1bEgM+eobxskWqBbx8bbUhPqH61Bm8fUCegvbgta8YHLKRF2fJ7EMkSXB8ghHQiiWTh1qj7Sz5lUNVGlOwwvXGiVMTLNaTLM+yO/I4Z8+94VkMTkdF4GVP7mn0jx3o84hZ3ZfcKgdD3bWl+e5vLboKb5F4mxMBto85+0F7iI0vnko9mAVHkGKpJjDwf5'
-
-ci_environment::jenkins_master::jenkins_servername: 'ci.alphagov.co.uk'
-ci_environment::jenkins_master::github_enterprise_cert: |
-    -----BEGIN CERTIFICATE-----
-    MIIEdDCCA1ygAwIBAgIJAKt4YiHj0+tVMA0GCSqGSIb3DQEBBQUAMIGCMQswCQYD
-    VQQGEwJHQjEPMA0GA1UECBMGTG9uZG9uMQ8wDQYDVQQHEwZMb25kb24xFzAVBgNV
-    BAoTDkNhYmluZXQgT2ZmaWNlMSMwIQYDVQQLExpHb3Zlcm5tZW50IERpZ2l0YWwg
-    U2VydmljZTETMBEGA1UEAxMKZ2l0aHViLmdkczAeFw0xMzAxMDcxNTE5MjhaFw0x
-    ODAxMDYxNTE5MjhaMIGCMQswCQYDVQQGEwJHQjEPMA0GA1UECBMGTG9uZG9uMQ8w
-    DQYDVQQHEwZMb25kb24xFzAVBgNVBAoTDkNhYmluZXQgT2ZmaWNlMSMwIQYDVQQL
-    ExpHb3Zlcm5tZW50IERpZ2l0YWwgU2VydmljZTETMBEGA1UEAxMKZ2l0aHViLmdk
-    czCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANiLTHwolRWmRZeIeboY
-    4L4VUoMv6zg0rovpzX1hdzdJ5Gn6OoxaADO78Al85/9jRXIYyun6d9iRAknb1ZrG
-    yxLQ8mmMl8rqbHa/mBK42G5NVL703712NslcNfeY/FvvdtVBjUI1EIRbehDYMYET
-    aqX88HAvohyIoe1LJ4+6t2hF+P1dP7DQvxcu4eBlaywssbvt+FVnYIY87X6CdrVe
-    bkMWh0C7J32uY4lEyamcl/M//KjJWFDBkFTbdguZW+KeFwfecVh+OpsdNRKzI3vX
-    zriHE7icrJWw5jssE2ZMregLfc1bZ5zpPljEFVxDzyIuseUuVxYQSr1GNwrzr1ix
-    LIECAwEAAaOB6jCB5zAdBgNVHQ4EFgQUxjT7A9kz7MecUpg6QCMWteDYF7wwgbcG
-    A1UdIwSBrzCBrIAUxjT7A9kz7MecUpg6QCMWteDYF7yhgYikgYUwgYIxCzAJBgNV
-    BAYTAkdCMQ8wDQYDVQQIEwZMb25kb24xDzANBgNVBAcTBkxvbmRvbjEXMBUGA1UE
-    ChMOQ2FiaW5ldCBPZmZpY2UxIzAhBgNVBAsTGkdvdmVybm1lbnQgRGlnaXRhbCBT
-    ZXJ2aWNlMRMwEQYDVQQDEwpnaXRodWIuZ2RzggkAq3hiIePT61UwDAYDVR0TBAUw
-    AwEB/zANBgkqhkiG9w0BAQUFAAOCAQEASTEwAV+wKUbQcBOKAWsZpPAxw168uRU/
-    KVp7XRE7XyOZUPL2OJ9RLRZz1hCgOuwx304DVLfQVeDp+uhsQzmkdxbBto23ejyh
-    8gXdHEnbjf2FN1dVomcDo7jqAqBU7Ji/c7sCLU/2z3ILt0fzwrEj3WQOl7dqYxY1
-    qruyrjFTQOclWUJKzHqlIKr3iBFVE0Z1EVywWKeV1CwKkikYhTjZGs0goCy0LHrj
-    LG8Mr4r1mOsqtUPYYjCN77EOwkRUucvIt1zNPoiD21OXzzxdOIUOUq6l/kERSfba
-    LWIWJn/KXkog8bU776IixxWlO8l1TwiCUoDS9YsLIKIRCT74QE48qA==
-    -----END CERTIFICATE-----
-
 # Self signed. For transition-logs development.
 cdn_logs::key: |
   -----BEGIN RSA PRIVATE KEY-----
@@ -114,6 +71,49 @@ cdn_logs::cert: |
   ywj3Z5o8PdM49oUR1rmQt2eQPRvMo8Rzh6xqNaV54t3dslOfL2Hre+dS63U/8cvu
   OmQVTqKNteZopB3dwsc4la9Y5PMCJ8OlJcm5BrV4A8mD
   -----END CERTIFICATE-----
+
+ci_environment::github_sshkeys::github_dotcom_key: 'AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
+
+ci_environment::github_sshkeys::github_dotgds_key: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDJsR5gu4+LPnomBEO37hY0l1chnD6U3eA1EHUg/o5op95dal49ZEvVEGtDCWyzwb2AF82/+APwCEHmAGF9l0suG5mU/VvtH4ne+S1Kji0TY+67t5rDDmckC0hqSkBxBrDyHROkXtRIyc/dyyuRhQBgW6zY1bEgM+eobxskWqBbx8bbUhPqH61Bm8fUCegvbgta8YHLKRF2fJ7EMkSXB8ghHQiiWTh1qj7Sz5lUNVGlOwwvXGiVMTLNaTLM+yO/I4Z8+94VkMTkdF4GVP7mn0jx3o84hZ3ZfcKgdD3bWl+e5vLboKb5F4mxMBto85+0F7iI0vnko9mAVHkGKpJjDwf5'
+
+ci_environment::jenkins_master::github_enterprise_cert: |
+    -----BEGIN CERTIFICATE-----
+    MIIEdDCCA1ygAwIBAgIJAKt4YiHj0+tVMA0GCSqGSIb3DQEBBQUAMIGCMQswCQYD
+    VQQGEwJHQjEPMA0GA1UECBMGTG9uZG9uMQ8wDQYDVQQHEwZMb25kb24xFzAVBgNV
+    BAoTDkNhYmluZXQgT2ZmaWNlMSMwIQYDVQQLExpHb3Zlcm5tZW50IERpZ2l0YWwg
+    U2VydmljZTETMBEGA1UEAxMKZ2l0aHViLmdkczAeFw0xMzAxMDcxNTE5MjhaFw0x
+    ODAxMDYxNTE5MjhaMIGCMQswCQYDVQQGEwJHQjEPMA0GA1UECBMGTG9uZG9uMQ8w
+    DQYDVQQHEwZMb25kb24xFzAVBgNVBAoTDkNhYmluZXQgT2ZmaWNlMSMwIQYDVQQL
+    ExpHb3Zlcm5tZW50IERpZ2l0YWwgU2VydmljZTETMBEGA1UEAxMKZ2l0aHViLmdk
+    czCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANiLTHwolRWmRZeIeboY
+    4L4VUoMv6zg0rovpzX1hdzdJ5Gn6OoxaADO78Al85/9jRXIYyun6d9iRAknb1ZrG
+    yxLQ8mmMl8rqbHa/mBK42G5NVL703712NslcNfeY/FvvdtVBjUI1EIRbehDYMYET
+    aqX88HAvohyIoe1LJ4+6t2hF+P1dP7DQvxcu4eBlaywssbvt+FVnYIY87X6CdrVe
+    bkMWh0C7J32uY4lEyamcl/M//KjJWFDBkFTbdguZW+KeFwfecVh+OpsdNRKzI3vX
+    zriHE7icrJWw5jssE2ZMregLfc1bZ5zpPljEFVxDzyIuseUuVxYQSr1GNwrzr1ix
+    LIECAwEAAaOB6jCB5zAdBgNVHQ4EFgQUxjT7A9kz7MecUpg6QCMWteDYF7wwgbcG
+    A1UdIwSBrzCBrIAUxjT7A9kz7MecUpg6QCMWteDYF7yhgYikgYUwgYIxCzAJBgNV
+    BAYTAkdCMQ8wDQYDVQQIEwZMb25kb24xDzANBgNVBAcTBkxvbmRvbjEXMBUGA1UE
+    ChMOQ2FiaW5ldCBPZmZpY2UxIzAhBgNVBAsTGkdvdmVybm1lbnQgRGlnaXRhbCBT
+    ZXJ2aWNlMRMwEQYDVQQDEwpnaXRodWIuZ2RzggkAq3hiIePT61UwDAYDVR0TBAUw
+    AwEB/zANBgkqhkiG9w0BAQUFAAOCAQEASTEwAV+wKUbQcBOKAWsZpPAxw168uRU/
+    KVp7XRE7XyOZUPL2OJ9RLRZz1hCgOuwx304DVLfQVeDp+uhsQzmkdxbBto23ejyh
+    8gXdHEnbjf2FN1dVomcDo7jqAqBU7Ji/c7sCLU/2z3ILt0fzwrEj3WQOl7dqYxY1
+    qruyrjFTQOclWUJKzHqlIKr3iBFVE0Z1EVywWKeV1CwKkikYhTjZGs0goCy0LHrj
+    LG8Mr4r1mOsqtUPYYjCN77EOwkRUucvIt1zNPoiD21OXzzxdOIUOUq6l/kERSfba
+    LWIWJn/KXkog8bU776IixxWlO8l1TwiCUoDS9YsLIKIRCT74QE48qA==
+    -----END CERTIFICATE-----
+ci_environment::jenkins_master::jenkins_servername: 'ci.alphagov.co.uk'
+
+# Version potentially overridden on individual ci-slave machines
+gds_elasticsearch::version: '1.4.4'
+gds_elasticsearch::number_of_replicas: 0
+
+jenkins::lts: 1
+
+locales::default_value: en_GB.UTF-8
+locales::available:
+  - "en_GB.UTF-8 UTF-8"
 
 nginx::config::confd_purge: true
 nginx::config::vhost_purge: true

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -109,8 +109,6 @@ ci_environment::jenkins_master::jenkins_servername: 'ci.alphagov.co.uk'
 gds_elasticsearch::version: '1.4.4'
 gds_elasticsearch::number_of_replicas: 0
 
-jenkins::lts: 1
-
 locales::default_value: en_GB.UTF-8
 locales::available:
   - "en_GB.UTF-8 UTF-8"

--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -8,19 +8,6 @@ apt::sources:
     repos: 'main dependencies'
     key: '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30'
 
-jenkins::slave::broadcast_address: 172.16.11.255
-
-gds_accounts::purge_ignore:
-  - 'vagrant'
-  - 'vboxadd'
-
-gds_dns::server::hosts: |
-    172.16.11.10 ci-master-1 master
-    172.16.11.11 ci-slave-1 slave
-    172.16.11.12 ci-slave-2 slave
-    172.16.11.13 ci-management-1 management
-    172.16.11.20 transition-logs-1 transition-logs
-
 ci_environment::jenkins_master::jenkins_serveraliases:
   - '172.16.11.10'
 
@@ -34,18 +21,30 @@ ci_environment::jenkins_user::pypi_live_password: ''
 ci_environment::jenkins_user::npm_auth: 'an_auth_token'
 ci_environment::jenkins_user::npm_email: 'an-email-address@gov.uk'
 
+gds_accounts::purge_ignore:
+  - 'vagrant'
+  - 'vboxadd'
+
+gds_dns::server::hosts: |
+    172.16.11.10 ci-master-1 master
+    172.16.11.11 ci-slave-1 slave
+    172.16.11.12 ci-slave-2 slave
+    172.16.11.13 ci-management-1 management
+    172.16.11.20 transition-logs-1 transition-logs
+
 gds_elasticsearch::heap_size: "64m"
 
+jenkins::slave::broadcast_address: 172.16.11.255
 # The token will need to be reset after each master install.
 jenkins::slave::ui_user: 'slave'
 jenkins::slave::ui_pass: 'REDACTED'
 
-mysql::server::config_hash:
-  root_password: password
-
 mongodb::smallfiles: true
 mongodb::noprealloc: true
 mongodb::nojournal: true
+
+mysql::server::config_hash:
+  root_password: password
 
 pact_broker::auth_password: letmein
 pact_broker::db_password: secret123

--- a/hieradata/role.ci-slave.yaml
+++ b/hieradata/role.ci-slave.yaml
@@ -1,6 +1,4 @@
 ---
-apt::unattended_upgrades::auto_reboot: true
-
 classes:
  - git
  - ci_environment::jenkins_slave
@@ -8,15 +6,18 @@ classes:
  - mongodb
  - gds_mongodb
 
+apt::unattended_upgrades::auto_reboot: true
+
 ci_environment::jenkins_slave::jenkins_home: /home/jenkins
+
+gds_mongodb::members: ['localhost']
+gds_mongodb::replSet: 'gds-ci'
 
 jenkins::slave::manage_slave_user: 1
 jenkins::slave::slave_user: jenkins
 jenkins::slave::slave_home: /home/jenkins
 jenkins::slave::version: 1.9
+
 mongodb::replSet: 'gds-ci'
 mongodb::enable_10gen: true
 mongodb::version: 2.4.9
-gds_mongodb::members: ['localhost']
-gds_mongodb::replSet: 'gds-ci'
-

--- a/hieradata/role.transition-logs.yaml
+++ b/hieradata/role.transition-logs.yaml
@@ -9,8 +9,6 @@ classes:
 
 apt::unattended_upgrades::auto_reboot: false
 
-ssh::server::subsystem_sftp: /usr/lib/openssh/sftp-server -f LOCAL7 -l VERBOSE
-
 ci_environment::transition_logs::rssh_users:
     mhra:
         comment: "MHRA"
@@ -211,3 +209,5 @@ ci_environment::transition_logs::rssh_users:
         comment: "Apprenticeships"
         ssh_key: AAAAB3NzaC1yc2EAAAABJQAAAQEAhael8c2CCipKECB57cTZ1ClwiDWiXV66CMUq0bsW9GiSjAaPsKjA7PyKoOiXbm5wiNUVqZc1fbNPwW9iNr4GsC5DGkCw7KJDJhwRA2k6c3NqbGTEcneYgIAtKprHR3LeoR7+C7GHVLUFQ7yJiSOpu8SO9cTT3161Qy9G3oYf2QF3NY1DfG4VcekrlLGiM4pu9aA2mpnlGnsUcU6Sg0C0niHZUodgvbf0wcv9RFB/REg+PbmMrJWW9XLXDc01cC6jtH/bTwac8eEwdHkDUscRb9Wny0yn4+8a/SlfpMguVbFl7GNPeche1j2ADfmrKFbK3tp+jxkeqOiJ2UpyFFPHAQ==
         home_dir: /srv/logs/log-1/sfa_apporg
+
+ssh::server::subsystem_sftp: /usr/lib/openssh/sftp-server -f LOCAL7 -l VERBOSE

--- a/modules/ci_environment/manifests/jenkins_master.pp
+++ b/modules/ci_environment/manifests/jenkins_master.pp
@@ -25,8 +25,18 @@ class ci_environment::jenkins_master (
   validate_string($github_enterprise_cert, $jenkins_servername, $jenkins_home)
   validate_array($jenkins_serveraliases)
 
+  apt::source { 'govuk-jenkins':
+    location     => 'http://apt.production.alphagov.co.uk/govuk-jenkins',
+    release      => 'stable',
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    include_src  => false,
+  }
+
   include java
-  include jenkins
+  class { 'jenkins':
+    repo => 0,
+  }
   include jenkins_user
   include jenkins_job_support
 


### PR DESCRIPTION
The version of Jenkins we're using is no longer available in the
official apt repo (it only has the latest version). It's also very slow.

Using our own mirror avoids both of these issues.


This also includes a commit to alphabetise the hieradata.