### PR TITLE
Fix warning from template not using @ variable.

### DIFF
--- a/modules/ci_environment/templates/etc/fail2ban/jail.local.erb
+++ b/modules/ci_environment/templates/etc/fail2ban/jail.local.erb
@@ -5,4 +5,4 @@
 # "ignoreip" can be an IP address, a CIDR mask or a DNS host. Fail2ban
 # will not ban a host which matches an address in this list. Several
 # addresses can be defined using space separator.
-ignoreip = <%= whitelist_ips.join(" ") %>
+ignoreip = <%= @whitelist_ips.join(" ") %>


### PR DESCRIPTION
This was causing the following warning when running:

```
Variable access via 'whitelist_ips' is deprecated. Use '@whitelist_ips' instead.
template[/tmp/vagrant-puppet/modules-23039c89beb50fcef185f61334e7b97e/ci_environment/templates/etc/fail2ban/jail.local.erb]:8
```