### PR TITLE
Move CI to new domain

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -103,7 +103,6 @@ ci_environment::jenkins_master::github_enterprise_cert: |
     LG8Mr4r1mOsqtUPYYjCN77EOwkRUucvIt1zNPoiD21OXzzxdOIUOUq6l/kERSfba
     LWIWJn/KXkog8bU776IixxWlO8l1TwiCUoDS9YsLIKIRCT74QE48qA==
     -----END CERTIFICATE-----
-ci_environment::jenkins_master::jenkins_servername: 'ci.alphagov.co.uk'
 
 # Version potentially overridden on individual ci-slave machines
 gds_elasticsearch::version: '1.4.4'

--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -8,8 +8,8 @@ apt::sources:
     repos: 'main dependencies'
     key: '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30'
 
-ci_environment::jenkins_master::jenkins_serveraliases:
-  - '172.16.11.10'
+ci_environment::jenkins_master::vhost: 'ci.example.com'
+ci_environment::jenkins_master::legacy_vhost: 'old-ci.example.com'
 
 ci_environment::jenkins_user::rubygems_api_key: 'a_rubygems_key'
 ci_environment::jenkins_user::gemfury_api_key: 'a_gemfury_key'


### PR DESCRIPTION
This sets it up to run in parallel on both the old and new domains while
things are tested and migrated. Once we're happy, the old domain will be
setup to redirect to the new one.

This also removes the `serveraliases` because there's no need for any of these vhosts to have more than one name.

**Note:** This needs to be merged along with https://github.gds/gds/ci-deployment/pull/69