### PR TITLE
Simplify pact broker upstart config and pass creds in ENV vars

### DIFF
--- a/modules/pact_broker/files/config.ru
+++ b/modules/pact_broker/files/config.ru
@@ -4,7 +4,7 @@ require 'sequel'
 # require 'pg' # for postgres
 require 'pact_broker'
 
-db_url = "postgres://<%= @db_user %>:<%= CGI.escape(@db_password) %>@localhost/<%= @db_name %>"
+db_url = ENV.fetch('DATABASE_URL')
 
 # For postgres:
 # $ psql postgres
@@ -25,8 +25,10 @@ class NonGetBasicAuth < Rack::Auth::Basic
   end
 end
 
+AUTH_USERNAME = ENV.fetch('AUTH_USERNAME')
+AUTH_PASSWORD = ENV.fetch('AUTH_PASSWORD')
 use NonGetBasicAuth, "Restricted write access" do |username, password|
-  username == "<%= @auth_user %>" && password == "<%= @auth_password %>"
+  username == AUTH_USERNAME && password == AUTH_PASSWORD
 end
 
 # Version handler that supports branch names as well as numeric versions.

--- a/modules/pact_broker/manifests/app.pp
+++ b/modules/pact_broker/manifests/app.pp
@@ -5,11 +5,6 @@
 class pact_broker::app (
   $app_root,
   $user,
-  $db_user,
-  $db_password,
-  $db_name,
-  $auth_user,
-  $auth_password,
 ) {
   $ruby_version = '2.2.3'
 
@@ -49,7 +44,6 @@ class pact_broker::app (
   }
 
   file { "${app_root}/config.ru":
-    content => template('pact_broker/config.ru.erb'),
-    mode    => '0600',
+    source => 'puppet:///modules/pact_broker/config.ru',
   }
 }

--- a/modules/pact_broker/manifests/init.pp
+++ b/modules/pact_broker/manifests/init.pp
@@ -67,14 +67,9 @@ class pact_broker (
 
   # Application
   class { 'pact_broker::app':
-    app_root      => "${deploy_dir}/app",
-    user          => $user,
-    db_user       => $db_user,
-    db_password   => $db_password,
-    db_name       => $db_name,
-    auth_user     => $auth_user,
-    auth_password => $auth_password,
-    require       => User[$user],
+    app_root => "${deploy_dir}/app",
+    user     => $user,
+    require  => User[$user],
   }
 
   # Database
@@ -84,11 +79,16 @@ class pact_broker (
   }
 
   class { 'pact_broker::service':
-    deploy_dir => $deploy_dir,
-    user       => $user,
-    port       => $port,
-    subscribe  => Class['pact_broker::app'],
-    require    => Postgresql::Server::Db[$db_name],
+    deploy_dir    => $deploy_dir,
+    user          => $user,
+    port          => $port,
+    db_user       => $db_user,
+    db_password   => $db_password,
+    db_name       => $db_name,
+    auth_user     => $auth_user,
+    auth_password => $auth_password,
+    subscribe     => Class['pact_broker::app'],
+    require       => Postgresql::Server::Db[$db_name],
   }
 
   file { '/etc/logrotate.d/pact_broker':

--- a/modules/pact_broker/manifests/init.pp
+++ b/modules/pact_broker/manifests/init.pp
@@ -92,9 +92,9 @@ class pact_broker (
   }
 
   file { '/etc/logrotate.d/pact_broker':
-    source => 'puppet:///modules/pact_broker/logrotate',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
+    content => template('pact_broker/logrotate.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
   }
 }

--- a/modules/pact_broker/manifests/service.pp
+++ b/modules/pact_broker/manifests/service.pp
@@ -24,6 +24,17 @@ class pact_broker::service (
     notify  => Service['pact-broker'],
   }
 
+  file { [
+    '/var/log/pact_broker.log',
+    '/var/log/pact_broker.err.log',
+  ]:
+    ensure => present,
+    owner  => $user,
+    group  => $user,
+    mode   => '0644',
+    before => Service['pact-broker'],
+  }
+
   service { 'pact-broker':
     ensure => running,
     enable => true,

--- a/modules/pact_broker/manifests/service.pp
+++ b/modules/pact_broker/manifests/service.pp
@@ -6,6 +6,11 @@ class pact_broker::service (
   $deploy_dir,
   $user,
   $port,
+  $db_user,
+  $db_password,
+  $db_name,
+  $auth_user,
+  $auth_password,
 ) {
 
   file { "${deploy_dir}/unicorn.rb":
@@ -19,7 +24,7 @@ class pact_broker::service (
   file { '/etc/init/pact-broker.conf':
     owner   => 'root',
     group   => 'root',
-    mode    => '0644',
+    mode    => '0640', # Contains creds so can't be world-readable
     content => template('pact_broker/upstart.conf.erb'),
     notify  => Service['pact-broker'],
   }

--- a/modules/pact_broker/templates/logrotate.erb
+++ b/modules/pact_broker/templates/logrotate.erb
@@ -4,4 +4,5 @@
   rotate 5
   compress
   delaycompress
+  create <%= @user %> <%= @user %>
 }

--- a/modules/pact_broker/templates/upstart.conf.erb
+++ b/modules/pact_broker/templates/upstart.conf.erb
@@ -14,6 +14,10 @@ setuid <%= @user %>
 setgid <%= @user %>
 chdir <%= @deploy_dir %>/app
 
+env DATABASE_URL='postgres://<%= @db_user %>:<%= CGI.escape(@db_password) %>@localhost/<%= @db_name %>'
+env AUTH_USERNAME='<%= @auth_user %>'
+env AUTH_PASSWORD='<%= @auth_password %>'
+
 script
   # Using `bash -l` to pick up profile including rbenv setup
   exec bash -l -c "exec bundle exec unicorn -c <%= @deploy_dir %>/unicorn.rb" \

--- a/modules/pact_broker/templates/upstart.conf.erb
+++ b/modules/pact_broker/templates/upstart.conf.erb
@@ -10,11 +10,13 @@ respawn
 # and should be killed off.
 respawn limit 5 20
 
+setuid <%= @user %>
+setgid <%= @user %>
+chdir <%= @deploy_dir %>/app
+
 script
-  cd <%= @deploy_dir %>/app
   # Using `bash -l` to pick up profile including rbenv setup
-  exec sudo -u <%= @user %> \
-    bash -l -c "exec bundle exec unicorn -c <%= @deploy_dir %>/unicorn.rb" \
+  exec bash -l -c "exec bundle exec unicorn -c <%= @deploy_dir %>/unicorn.rb" \
     >>/var/log/pact_broker.log \
     2>>/var/log/pact_broker.err.log
 end script


### PR DESCRIPTION
Upstart versions after 1.4 (precise ships with 1.5) have `setuid` and
`setgid` directives, so there's no need to use sudo. This means that it's
now much easier to use ENV vars to pass credentials to the app, so this
also makes that change.