### PR TITLE
Give ci-master-1 vagrant machine 1Gig of RAM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ def vagrant_config(config, version)
   dist = ENV['gds_ci_dist'] || DIST_PREFERRED
 
   nodes = {
-    'ci-master-1' => {:ip => '172.16.11.10'},
+    'ci-master-1' => {:ip => '172.16.11.10', :memory => 1024},
     'ci-slave-1'  => {:ip => '172.16.11.11'},
     'ci-slave-2'  => {:ip => '172.16.11.12'},
     'ci-slave-3'  => {:ip => '172.16.11.13'},


### PR DESCRIPTION
The default of 384M isn't enough for this VM, and leads to provisioning
errors as the OOM killer gets triggered.