### PR TITLE
Add postgis for mapit

### DIFF
--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -8,6 +8,8 @@ apt::sources:
     repos: 'main dependencies'
     key: '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30'
 
+ci_environment::jenkins_job_support::postgresql::mapit_role_password: 'mapit'
+
 ci_environment::jenkins_master::vhost: 'ci.example.com'
 ci_environment::jenkins_master::legacy_vhost: 'old-ci.example.com'
 

--- a/modules/ci_environment/manifests/jenkins_job_support/postgresql.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/postgresql.pp
@@ -10,4 +10,16 @@ class ci_environment::jenkins_job_support::postgresql {
       password_hash => postgresql_password('jenkins', 'jenkins'),
       createdb      => true;
   }
+
+  # For mapit
+  class { 'postgresql::server::postgis': }
+
+  # The mapit role needs to be a superuser in order to load the PostGIS
+  # extension for the test database.
+  postgresql::server::role {
+    'mapit':
+      superuser     => true,
+      password_hash => postgresql_password('mapit', 'mapit');
+  }
+
 }

--- a/modules/ci_environment/manifests/jenkins_job_support/postgresql.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/postgresql.pp
@@ -1,6 +1,8 @@
 # == Class: ci_environment::jenkins_job_support::postgresql
 # Installs postgresql on the server
-class ci_environment::jenkins_job_support::postgresql {
+class ci_environment::jenkins_job_support::postgresql (
+  $mapit_role_password,
+) {
   include postgresql::server
   include postgresql::server::contrib
   include postgresql::lib::devel
@@ -19,7 +21,7 @@ class ci_environment::jenkins_job_support::postgresql {
   postgresql::server::role {
     'mapit':
       superuser     => true,
-      password_hash => postgresql_password('mapit', 'mapit');
+      password_hash => postgresql_password('mapit', $mapit_role_password);
   }
 
 }

--- a/modules/ci_environment/spec/jenkins_slave_spec.rb
+++ b/modules/ci_environment/spec/jenkins_slave_spec.rb
@@ -12,6 +12,7 @@ describe 'ci_environment::jenkins_slave', :type => :class do
     :kernel => 'Linux',
   }}
   let(:hiera_data) {{
+    'ci_environment::jenkins_job_support::postgresql::mapit_role_password' => 'mapit',
     'ci_environment::jenkins_user::rubygems_api_key' => 'a_rubygems_key',
     'ci_environment::jenkins_user::gemfury_api_key' => 'a_gemfury_key',
     'ci_environment::jenkins_user::pypi_username' => 'pp-developers',


### PR DESCRIPTION
For: https://trello.com/c/i0DJVKw9/134-mapit-ci-builds

Mapit needs the postgis extension available and also needs to be a postgres superuser to install the extension in the test db when it creates it.  We follow the pattern used in puppet (see https://github.gds/gds/puppet/pull/3614) and create a postgres role specifically for mapit.