### PR TITLE
Remove transition mysql test db

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/mysql.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/mysql.pp
@@ -30,18 +30,6 @@ class ci_environment::jenkins_job_support::mysql {
       password => 'content_planner',
       require  => Class['::mysql::server'];
 
-    # FIXME: Remove once these databases are gone from CI machines
-    [
-      'datainsights_todays_activity_test',
-      'datainsight_weekly_reach_test',
-      'datainsights_format_success_test',
-      'datainsight_insidegov_test',
-    ]:
-      ensure   => 'absent',
-      user     => 'datainsight',
-      password => 'datainsight',
-      require  => Class['::mysql::server'];
-
     [
       'efg_test',
       'efg_test1',

--- a/modules/ci_environment/manifests/jenkins_job_support/mysql.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/mysql.pp
@@ -92,7 +92,9 @@ class ci_environment::jenkins_job_support::mysql {
       password => 'tariff',
       require  => Class['::mysql::server'];
 
+    # FIXME: Remove once this database has gone from CI machines
     'transition_test':
+      ensure   => 'absent',
       user     => 'transition',
       password => 'transition',
       require  => Class['::mysql::server'];


### PR DESCRIPTION
Transition has been on Postgres for over a year now.

Also clean up datainsight test database definitions.