### PR TITLE
Reduce mongodb journal size on slaves.

### DIFF
--- a/hieradata/role.ci-slave.yaml
+++ b/hieradata/role.ci-slave.yaml
@@ -21,3 +21,4 @@ jenkins::slave::version: 1.9
 mongodb::replSet: 'gds-ci'
 mongodb::enable_10gen: true
 mongodb::version: 2.4.9
+mongodb::smallfiles: true


### PR DESCRIPTION
By default mongodb takes 3GB per machine for its
journals.  Since these aren't important to us
during test runs, we can dramatically reduce them
to 128MB with this config change.