### PR TITLE
Add 2.1.8 and 2.2.4 support

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -76,6 +76,9 @@ class ci_environment::base {
   rbenv::version { '2.1.7':
     bundler_version => '1.10.6',
   }
+  rbenv::version { '2.1.8':
+    bundler_version => '1.11.2',
+  }
   rbenv::alias { '2.1':
     to_version => '2.1.7'
   }
@@ -85,6 +88,9 @@ class ci_environment::base {
   }
   rbenv::version { '2.2.3':
     bundler_version => '1.10.6',
+  }
+  rbenv::version { '2.2.4':
+    bundler_version => '1.11.2',
   }
   rbenv::alias { '2.2':
     to_version => '2.2.3'


### PR DESCRIPTION
A new version of Ruby has been [released](https://www.ruby-lang.org/en/news/2015/12/16/ruby-2-2-4-released), but trying to prepare a project for the upgrade fails on [CI](https://github.com/alphagov/smart-answers/pull/2199):
```
rbenv: version `2.2.4' is not installed
rbenv: version `2.2.4' is not installed
Build step 'Execute shell' marked build as failure
An attempt to send an e-mail to empty list of recipients, ignored.
Finished: FAILURE
```

Includes fix for [CVE-2015-7551: Unsafe tainted string usage in Fiddle and DL](https://www.ruby-lang.org/en/news/2015/12/16/unsafe-tainted-string-usage-in-fiddle-and-dl-cve-2015-7551/)
