### PR TITLE
Use `@` to access `log_dir` in template

### DIFF
--- a/modules/cdn_logs/templates/etc/logrotate.cdn_logs.conf.erb
+++ b/modules/cdn_logs/templates/etc/logrotate.cdn_logs.conf.erb
@@ -1,4 +1,4 @@
-<%= log_dir -%>/*.log
+<%= @log_dir -%>/*.log
 {
   rotate 8760
   dateext


### PR DESCRIPTION
> Variable access via `log_dir` is deprecated