### PR TITLE
Remove unused kernels

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -4,6 +4,7 @@ classes:
   - apt::unattended_upgrades
   - ci_environment::base
   - ci_environment::dns
+  - ci_environment::unused_kernels
   - gds_collectd
   - gds_accounts
   - ci_environment::firewall_config::base

--- a/modules/ci_environment/files/etc/cron.daily/remove_unused_kernels
+++ b/modules/ci_environment/files/etc/cron.daily/remove_unused_kernels
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e -o pipefail
+
+PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ubuntu-unused-kernels | xargs -r apt-get -y purge

--- a/modules/ci_environment/manifests/unused_kernels.pp
+++ b/modules/ci_environment/manifests/unused_kernels.pp
@@ -1,0 +1,16 @@
+# Class: ci_environment::unused_kernels
+#
+# Periodically remove packages for Ubuntu kernels that are no longer used in
+# order to reclaim disk space (inodes).
+#
+class ci_environment::unused_kernels {
+  package { 'ubuntu_unused_kernels':
+    ensure   => '0.2.0',
+    provider => 'gem',
+  } ->
+  file { '/etc/cron.daily/remove_unused_kernels':
+    ensure => present,
+    source => 'puppet:///modules/ci_environment/etc/cron.daily/remove_unused_kernels',
+    mode   => '0755',
+  }
+}


### PR DESCRIPTION
Unused kernels take up disk space (and more importantly disk inodes).

This commit adds the same code that's used in govuk_mirror-puppet to set up a script which runs daily to remove kernels that aren't being used.