### PR TITLE
Attempt to fix login with GitHub Enterprise

### DIFF
--- a/hieradata/role.ci-master.yaml
+++ b/hieradata/role.ci-master.yaml
@@ -83,6 +83,6 @@ jenkins::plugin_hash:
     build-pipeline-plugin:
         version: "1.3.3"
     github-oauth:
-        version: "0.22"
+        version: "0.19"
     rebuild:
         version: "1.22"


### PR DESCRIPTION
Since the GitHub Enterprise upgrade on 2016-01-20 to Version 2.4.3, several
users (possibly all users) are seeing an error at login time that seems to be
related to the GitHub OAuth interaction. The deploy Jenkins do not have the
same problem and are using this earlier version of the github-oauth plugin.

Here are two snippets from the stack trace that Jenkins shows to users:
```
java.io.IOException: {"message":"You need at least read:org scope or user scope to list your organizations.","documentation_url":"https://developer.github.com/enterprise/2.4/v3/orgs/#list-your-organizations"}
	at org.kohsuke.github.Requester.handleApiError(Requester.java:342)
```
and:
```
Caused by: java.io.IOException: Server returned HTTP response code: 403 for URL: https://github.gds/api/v3/user/orgs
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1628)
```

Here is the changelog for the plugin: https://wiki.jenkins-ci.org/display/JENKINS/Github+OAuth+Plugin#GithubOAuthPlugin-Releasenotes

Here are the release notes for GitHub Enterprise: https://enterprise.github.com/releases