### PR TITLE
Update puppet-lint and fix the warnings that ensue.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "librarian-puppet", '~> 2.0'
 # Testing utilities.
 gem 'rake'
 gem 'puppet-syntax'
-gem 'puppet-lint', '~> 0.3.0'
+gem 'puppet-lint', :github => 'rodjek/puppet-lint', :ref => '2546fe'
 gem 'rspec-puppet', '~> 0.1.0'
 gem 'puppetlabs_spec_helper', '~> 0.4.0'
 gem 'hiera-puppet-helper', :git => 'git://github.com/bobtfish/hiera-puppet-helper.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,13 @@ GIT
   specs:
     hiera-puppet-helper (2.0.1)
 
+GIT
+  remote: git://github.com/rodjek/puppet-lint.git
+  revision: 2546fed6be894bbcff15c3f48d4b6f6bc15d94d1
+  ref: 2546fe
+  specs:
+    puppet-lint (1.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -54,7 +61,6 @@ GEM
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
-    puppet-lint (0.3.2)
     puppet-syntax (1.2.0)
       puppet (>= 2.7.0)
       rake
@@ -92,7 +98,7 @@ DEPENDENCIES
   parallel (~> 1.0.0)
   parallel_tests (~> 0.16.10)
   puppet (= 3.7.1)
-  puppet-lint (~> 0.3.0)
+  puppet-lint!
   puppet-syntax
   puppetlabs_spec_helper (~> 0.4.0)
   rake

--- a/modules/cdn_logs/manifests/init.pp
+++ b/modules/cdn_logs/manifests/init.pp
@@ -34,8 +34,8 @@ class cdn_logs (
   }
 
   rsyslog::snippet { '10-cdn_remote':
-    content   => template('cdn_logs/etc/rsyslog.d/10-cdn_remote.conf.erb'),
-    require   => [
+    content => template('cdn_logs/etc/rsyslog.d/10-cdn_remote.conf.erb'),
+    require => [
       # Parent log dir and rsyslog configs.
       Class['ci_environment::transition_logs'],
       File[
@@ -47,8 +47,8 @@ class cdn_logs (
   }
 
   rsyslog::snippet { 'transition_logs_sftp':
-    content   => 'local7.*                       /var/log/sftp-server.log',
-    require   => [
+    content => 'local7.*                       /var/log/sftp-server.log',
+    require => [
       Class['ci_environment::transition_logs']
     ]
   }

--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -105,8 +105,8 @@ class ci_environment::base {
   }
 
   file { '/etc/ssh/ssh_known_hosts':
-    ensure  => present,
-    mode    => '0644',
+    ensure => present,
+    mode   => '0644',
   }
 
   include ssh::server

--- a/modules/ci_environment/manifests/jenkins_user.pp
+++ b/modules/ci_environment/manifests/jenkins_user.pp
@@ -17,11 +17,11 @@ class ci_environment::jenkins_user (
   validate_string($jenkins_home)
 
   file {'jenkins_sshdir':
-    ensure  => directory,
-    path    => "${jenkins_home}/.ssh",
-    owner   => 'jenkins',
-    group   => 'jenkins',
-    mode    => '0700',
+    ensure => directory,
+    path   => "${jenkins_home}/.ssh",
+    owner  => 'jenkins',
+    group  => 'jenkins',
+    mode   => '0700',
   }
 
   $private_key = "${jenkins_home}/.ssh/id_rsa"
@@ -33,19 +33,19 @@ class ci_environment::jenkins_user (
   }
 
   file {"${jenkins_home}/.gitconfig":
-    ensure  => 'present',
-    owner   => 'jenkins',
-    group   => 'nogroup',
-    mode    => '0644',
-    source  => 'puppet:///modules/ci_environment/jenkins-dot-gitconfig',
+    ensure => 'present',
+    owner  => 'jenkins',
+    group  => 'nogroup',
+    mode   => '0644',
+    source => 'puppet:///modules/ci_environment/jenkins-dot-gitconfig',
   }
 
   file {'jenkins_dotgem_dir':
-    ensure  => directory,
-    path    => "${jenkins_home}/.gem",
-    owner   => 'jenkins',
-    group   => 'jenkins',
-    mode    => '0700',
+    ensure => directory,
+    path   => "${jenkins_home}/.gem",
+    owner  => 'jenkins',
+    group  => 'jenkins',
+    mode   => '0700',
   }
 
   file {"${jenkins_home}/.gem/credentials":

--- a/modules/gds_elasticsearch/manifests/init.pp
+++ b/modules/gds_elasticsearch/manifests/init.pp
@@ -43,10 +43,10 @@ class gds_elasticsearch (
   }
 
   exec { 'disable-default-elasticsearch':
-    onlyif      => '/usr/bin/test -f /etc/init.d/elasticsearch',
-    command     => '/etc/init.d/elasticsearch stop && /bin/rm -f /etc/init.d/elasticsearch && /usr/sbin/update-rc.d elasticsearch remove',
-    before      => Elasticsearch::Instance[$::fqdn],
-    require     => Package['elasticsearch'],
+    onlyif  => '/usr/bin/test -f /etc/init.d/elasticsearch',
+    command => '/etc/init.d/elasticsearch stop && /bin/rm -f /etc/init.d/elasticsearch && /usr/sbin/update-rc.d elasticsearch remove',
+    before  => Elasticsearch::Instance[$::fqdn],
+    require => Package['elasticsearch'],
   }
 
   $instance_config = {

--- a/modules/gds_mongodb/manifests/init.pp
+++ b/modules/gds_mongodb/manifests/init.pp
@@ -1,10 +1,10 @@
 # class to configure a replica set
 class gds_mongodb($members, $replSet) {
   file { '/etc/mongodb':
-    ensure  => 'directory',
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    ensure => 'directory',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
   }
 
   file { '/etc/mongodb/configure-replica-set.js':


### PR DESCRIPTION
We'd like to install a lint plugin so we need a newer version of
puppet-lint. This commit gives us that newer version