### PR TITLE
Adding ruby 2.1.8 and 2.2.4 to the rbenv available options

### DIFF
--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -89,8 +89,11 @@ class ci_environment::base {
   rbenv::version { '2.2.3':
     bundler_version => '1.10.6',
   }
+  rbenv::version { '2.2.4':
+    bundler_version => '1.10.6',
+  }
   rbenv::alias { '2.2':
-    to_version => '2.2.3'
+    to_version => '2.2.4'
   }
 
   rbenv::version { '2.3.0':

--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -76,8 +76,11 @@ class ci_environment::base {
   rbenv::version { '2.1.7':
     bundler_version => '1.10.6',
   }
+  rbenv::version { '2.1.8':
+    bundler_version => '1.10.6',
+  }
   rbenv::alias { '2.1':
-    to_version => '2.1.7'
+    to_version => '2.1.8'
   }
 
   rbenv::version { '2.2.2':


### PR DESCRIPTION
Includes fix for [CVE-2015-7551: Unsafe tainted string usage in Fiddle and DL](https://www.ruby-lang.org/en/news/2015/12/16/unsafe-tainted-string-usage-in-fiddle-and-dl-cve-2015-7551/)

Also updates the aliases for 2.1 and 2.2 to patched new versions.

This PR supersedes #358 

