### PR TITLE
Set an explicit owner and group.

### DIFF
--- a/modules/ci_environment/manifests/unused_kernels.pp
+++ b/modules/ci_environment/manifests/unused_kernels.pp
@@ -11,6 +11,8 @@ class ci_environment::unused_kernels {
   file { '/etc/cron.daily/remove_unused_kernels':
     ensure => present,
     source => 'puppet:///modules/ci_environment/etc/cron.daily/remove_unused_kernels',
+    owner  => 'root',
+    group  => 'root',
     mode   => '0755',
   }
 }


### PR DESCRIPTION
This currently changes to the user running the fab script and so creates unneeded
churn in the logfiles.