### PR TITLE
Add nmap to Jenkins slaves

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -74,14 +74,14 @@ class ci_environment::jenkins_job_support {
     provider => gem,
   }
 
-  class { 'ci_environment::jenkins_job_support::mysql': }
-  class { 'ci_environment::jenkins_job_support::postgresql': }
-  class { 'ci_environment::jenkins_job_support::rabbitmq': }
+  include ci_environment::jenkins_job_support::mysql
+  include ci_environment::jenkins_job_support::postgresql
+  include ci_environment::jenkins_job_support::rabbitmq
   include ci_environment::jenkins_job_support::nmap
-  class { 'phantomjs': }
-  class { 'xvfb': } # Needed by capybara-webkit (used in Publisher)
+  include phantomjs
+  include xvfb # Needed by capybara-webkit (used in Publisher)
 
-  class { 'clamav': }
+  include clamav
 
   # asset-manager relies on this symlink being present
   # pointing at clamscan not clamdscan because the clamav user doesn't

--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -77,6 +77,7 @@ class ci_environment::jenkins_job_support {
   class { 'ci_environment::jenkins_job_support::mysql': }
   class { 'ci_environment::jenkins_job_support::postgresql': }
   class { 'ci_environment::jenkins_job_support::rabbitmq': }
+  include ci_environment::jenkins_job_support::nmap
   class { 'phantomjs': }
   class { 'xvfb': } # Needed by capybara-webkit (used in Publisher)
 

--- a/modules/ci_environment/manifests/jenkins_job_support/nmap.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/nmap.pp
@@ -1,0 +1,18 @@
+# == Class: ci_environment::jenkins_job_support::nmap
+#
+# Configures nmap, ready to be used by Jenkins jobs
+#
+class ci_environment::jenkins_job_support::nmap (){
+
+  package { 'nmap':
+    ensure => latest,
+  }
+
+  file { '/etc/sudoers.d/jenkins-nmap':
+    ensure  => present,
+    mode    => '0440',
+    content => 'jenkins ALL=NOPASSWD:/usr/bin/nmap
+',
+  }
+
+}


### PR DESCRIPTION
I plan to use nmap to verify our firewall configuration from an external
network. Add it to the Jenkins slaves so that it can be run from a
Jenkins job.

Add a sudoers config file so that jenkins can run nmap as root,
which is required for the types of scans we're doing.