### PR TITLE
Remove nmap from Jenkins slaves

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support/nmap.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/nmap.pp
@@ -4,12 +4,12 @@
 #
 class ci_environment::jenkins_job_support::nmap (){
 
+  # FIXME: Remove once deployed
   package { 'nmap':
-    ensure => latest,
+    ensure => purged,
   }
-
   file { '/etc/sudoers.d/jenkins-nmap':
-    ensure  => present,
+    ensure  => absent,
     mode    => '0440',
     content => 'jenkins ALL=NOPASSWD:/usr/bin/nmap
 ',


### PR DESCRIPTION
I added nmap to the Jenkins slaves so that we could port-scan our
external-facing IP addresses. The prototype for that was in:
https://github.gds/gds/govuk-provisioning/commit/241711aba3bf99d1295c864ff6812da1341bb5fe
https://github.gds/gds/govuk-provisioning/pull/528

The above prototype wasn't merged, so clean up and remove nmap from the
Jenkins slaves.