### PR TITLE
adds class for S3 backups

### DIFF
--- a/modules/ci_environment/manifests/transition_logs.pp
+++ b/modules/ci_environment/manifests/transition_logs.pp
@@ -113,4 +113,8 @@ class ci_environment::transition_logs {
       log_local  => true,
       log_remote => false,
     }
+
+  # S3 backups
+  include ci_environment::transition_logs::s3_backups
+
 }

--- a/modules/ci_environment/manifests/transition_logs/remote_users.pp
+++ b/modules/ci_environment/manifests/transition_logs/remote_users.pp
@@ -10,7 +10,7 @@ define ci_environment::transition_logs::remote_users (
     ssh_key  => $ssh_key,
     home_dir => $home_dir,
     shell    => '/usr/bin/rssh',
-    require  => Ext4mount['/srv/logs/log-1'],
+    require  => [Ext4mount['/srv/logs/log-1'], Package['rssh']],
   }
 
   file {"${home_dir}/cache":

--- a/modules/ci_environment/manifests/transition_logs/s3_backups.pp
+++ b/modules/ci_environment/manifests/transition_logs/s3_backups.pp
@@ -1,0 +1,46 @@
+# class ci_environment::transition_logs::s3_backups
+#
+# [*directory*]
+#   Defines the directory to backup
+#
+# [*hour*]
+#   Defines the hour to run the cron job
+#
+# [*minute*]
+#   Defines the minute to run the cron job
+#
+# [*retention*]
+#   Defines the number of full backups to retain
+#
+# [*s3_bucket*]
+#   Defines the AWS S3 bucket destination for backups
+#
+# [*s3_aws_id*]
+#   Defines the AWS access id with permission to write to 
+#   the S3 bucket
+#
+# [*s3_aws_key*]
+#   Defines the AWS access secret key for the defined aws access id
+
+class ci_environment::transition_logs::s3_backups(
+  $directory = '/srv/logs/log-1',
+  $hour = 4,
+  $minute = 15,
+  $retention = 30,
+  $s3_bucket = undef,
+  $s3_aws_id = undef,
+  $s3_aws_key = undef,
+  ){
+
+  duplicity { 'transition-logs-s3-backups':
+    directory             => $directory,
+    bucket                => $s3_bucket,
+    dest_id               => $s3_aws_id,
+    dest_key              => $s3_aws_key,
+    pubkey_id             => '13B84C37AB52D76B3F53CF0E7C34BD7A05119BA4',
+    hour                  => $hour,
+    minute                => $minute,
+    remove_all_but_n_full => $retention,
+  }
+
+}

--- a/modules/ci_environment/manifests/transition_logs/s3_backups.pp
+++ b/modules/ci_environment/manifests/transition_logs/s3_backups.pp
@@ -26,7 +26,7 @@ class ci_environment::transition_logs::s3_backups(
   $directory = '/srv/logs/log-1',
   $hour = 4,
   $minute = 15,
-  $retention = 30,
+  $retention = 4,
   $s3_bucket = undef,
   $s3_aws_id = undef,
   $s3_aws_key = undef,


### PR DESCRIPTION
We want to stop backing up to a remote server and backup to an
S3 bucket instead. We should backup everything in /srv/logs/log-1/
except for the cdn directory which contains the Bouncer CDN logs.