### PR TITLE
adds cron job to restart rsyslog if log is stale

### DIFF
--- a/modules/ci_environment/files/check_rsyslog_status_transition.sh
+++ b/modules/ci_environment/files/check_rsyslog_status_transition.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if ! /usr/lib/nagios/plugins/check_file_age -f /srv/logs/log-1/cdn/bouncer_and_redirector.log -c600 -w300 > /dev/null
+then
+    logger "ERROR: /srv/logs/log-1/cdn/bouncer_and_redirector.log is older than 5mins. Restarting rsyslog..."
+    sudo service rsyslog restart
+fi

--- a/modules/ci_environment/manifests/transition_logs.pp
+++ b/modules/ci_environment/manifests/transition_logs.pp
@@ -56,6 +56,12 @@ class ci_environment::transition_logs {
         require => Account['logs_processor'],
     }
 
+    file { '/usr/local/bin/check_rsyslog_status_transition':
+        ensure => present,
+        mode   => '0755',
+        source => 'puppet:///modules/ci_environment/check_rsyslog_status_transition.sh',
+    }
+
     cron { 'process_fastly_logs':
         ensure      => present,
         environment => 'PATH=/usr/lib/rbenv/shims:/usr/sbin:/usr/bin:/sbin:/bin',
@@ -67,13 +73,10 @@ class ci_environment::transition_logs {
         require     => File["${logs_processor_home}/process_transition_logs.sh"],
     }
 
-    cron { 'restart_rsyslog':
-        ensure      => present,
-        environment => 'PATH=/usr/sbin:/usr/bin:/sbin:/bin',
-        command     => 'service rsyslog restart',
-        user        => root,
-        hour        => absent,
-        minute      => 5,
+    cron { 'check_rsyslog_status_transition':
+        ensure  => present,
+        command => '/usr/local/bin/check_rsyslog_status_transition',
+        minute  => '*/5',
     }
 
     $accounts = hiera('ci_environment::transition_logs::rssh_users')
@@ -81,6 +84,7 @@ class ci_environment::transition_logs {
         'rssh',
         # Provides /opt/mawk required by pre-transition-stats for processing logs
         'mawk-1.3.4',
+        'nagios-plugins-basic',
         # We need to decompress some 7zipped agency logs
         'p7zip-full',
         'python-paramiko',


### PR DESCRIPTION
This code will check if the bouncer and redirector logs
on the transition server have updated within the last
5 minutes. If not, it will restart syslog.

See this commit to govuk-puppet repo for more info:
https://github.com/alphagov/govuk-puppet/commit/519b4099fa4e6982d0501705013be441ea53936e