### PR TITLE
adds cron job to restart rsyslog if log is stale

### DIFF
--- a/modules/ci_environment/files/check_rsyslog_status_transition.sh
+++ b/modules/ci_environment/files/check_rsyslog_status_transition.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+logger='/usr/bin/logger'
+service='/usr/sbin/service'
+check_file_age='/usr/lib/nagios/plugins/check_file_age'
+log_file='/srv/logs/log-1/cdn/bouncer_and_redirector.log'
+
+if ! $check_file_age -f $log_file -c600 -w300 > /dev/null
+then
+    $logger "ERROR: /srv/logs/log-1/cdn/bouncer_and_redirector.log is older than 5mins. Restarting rsyslog..."
+    $service rsyslog restart
+fi


### PR DESCRIPTION
This code will check if the bouncer and redirector logs
on the transition server have updated within the last
5 minutes. If not, it will restart syslog.

See this commit to govuk-puppet repo for more info:
https://github.com/alphagov/govuk-puppet/commit/519b4099fa4e6982d0501705013be441ea53936e