### PR TITLE
Add role for migration_checker script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /bin
 /build
 *.vdi
+.DS_Store

--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -9,6 +9,8 @@ apt::sources:
     key: '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30'
 
 ci_environment::jenkins_job_support::postgresql::mapit_role_password: 'mapit'
+ci_environment::jenkins_job_support::postgresql::migration_checker_role_password: 'migration_checker'
+
 
 ci_environment::jenkins_master::vhost: 'ci.example.com'
 ci_environment::jenkins_master::legacy_vhost: 'old-ci.example.com'

--- a/modules/ci_environment/manifests/jenkins_job_support/postgresql.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support/postgresql.pp
@@ -2,6 +2,7 @@
 # Installs postgresql on the server
 class ci_environment::jenkins_job_support::postgresql (
   $mapit_role_password,
+  $migration_checker_role_password,
 ) {
   include postgresql::server
   include postgresql::server::contrib
@@ -24,4 +25,11 @@ class ci_environment::jenkins_job_support::postgresql (
       password_hash => postgresql_password('mapit', $mapit_role_password);
   }
 
+  # For Finding Things migration checker
+  # https://github.com/alphagov/finding-things-migration-checker
+  postgresql::server::role {
+    'migration_checker':
+      superuser     => false,
+      password_hash => postgresql_password('migration_checker', $migration_checker_role_password);
+  }
 }

--- a/modules/ci_environment/spec/jenkins_slave_spec.rb
+++ b/modules/ci_environment/spec/jenkins_slave_spec.rb
@@ -13,6 +13,7 @@ describe 'ci_environment::jenkins_slave', :type => :class do
   }}
   let(:hiera_data) {{
     'ci_environment::jenkins_job_support::postgresql::mapit_role_password' => 'mapit',
+    'ci_environment::jenkins_job_support::postgresql::migration_checker_role_password' => 'migration_checker',
     'ci_environment::jenkins_user::rubygems_api_key' => 'a_rubygems_key',
     'ci_environment::jenkins_user::gemfury_api_key' => 'a_gemfury_key',
     'ci_environment::jenkins_user::pypi_username' => 'pp-developers',


### PR DESCRIPTION
On Finding Things Team, we have a [script][] that checks wether Publishing
API and Rummager are in sync, that script needs it's own database.

For more context: https://trello.com/c/DYFgXNYr/621-automate-link-checker-tool#comment-57307d3dae7007a4031b19c1

[script]: https://github.com/alphagov/finding-things-migration-checker