### PR TITLE
Bump the mongodb module version we use.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -35,6 +35,6 @@ mod 'alphagov/harden',        :git => 'git://github.com/alphagov/puppet-harden.g
 mod 'alphagov/jenkins',       :git => 'git://github.com/alphagov/puppet-jenkins.git',
                               :ref => 'ca40459bea5a9dc91e12e8014c9878fcd2856ee7'
 mod 'alphagov/mongodb',       :git => 'git://github.com/alphagov/puppetlabs-mongodb.git',
-                              :ref => 'dc077a209efdf8d80fac40d40fec575b6a0949d2'
+                              :ref => '1661646b1391c47417d1d25b0a541fdc53bf7729'
 mod 'alphagov/rsyslog',       :git => 'git://github.com/alphagov/puppet-rsyslog.git',
                               :ref => 'acf2755cda80e2ecd107ed8de4d275c383db0487'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -99,8 +99,8 @@ GIT
 
 GIT
   remote: git://github.com/alphagov/puppetlabs-mongodb.git
-  ref: dc077a209efdf8d80fac40d40fec575b6a0949d2
-  sha: dc077a209efdf8d80fac40d40fec575b6a0949d2
+  ref: 1661646b1391c47417d1d25b0a541fdc53bf7729
+  sha: 1661646b1391c47417d1d25b0a541fdc53bf7729
   specs:
     alphagov-mongodb (0.1.0)
       puppetlabs-apt (>= 0.0.2)


### PR DESCRIPTION
This include the full `apt-key` to stop warning messages.