### PR TITLE
Make estools depend on pip

### DIFF
--- a/modules/gds_elasticsearch/manifests/estools.pp
+++ b/modules/gds_elasticsearch/manifests/estools.pp
@@ -6,5 +6,6 @@ class gds_elasticsearch::estools {
   package { 'estools':
     ensure   => '1.1.1',
     provider => 'pip',
+    require  => Package['python-pip'],
   }
 }


### PR DESCRIPTION
estools is installed with pip so pip needs to be installed first.