### PR TITLE
Purge oracle-java7-installer

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -99,12 +99,7 @@ class ci_environment::jenkins_job_support {
     'set-licence-seen':
       command => '/bin/echo debconf shared/accepted-oracle-license-v1-1 seen true | /usr/bin/debconf-set-selections';
   }
-  # Install Java 7 for ElasticSearch
-  package { 'oracle-java7-installer':
-    ensure  => present,
-    require => [Exec['set-licence-selected'], Exec['set-licence-seen']],
-  }
-  # Install Java 8 for Licensify
+  # Install Java 8 for Licensify and Elasticsearch
   package { 'oracle-java8-installer':
     ensure  => present,
     require => [Exec['set-licence-selected'], Exec['set-licence-seen']],
@@ -116,6 +111,7 @@ class ci_environment::jenkins_job_support {
       'openjsk-6-jre',
       'openjdk-6-jre-headless',
       'openjdk-6-jre-lib',
+      'oracle-java7-installer',
     ]:
       ensure => purged;
   }


### PR DESCRIPTION
The package for oracle-java7-installer that we have available in our PPA uses an old copy of the download from download.oracle.com which means that the shasum doesn't match so the installation fails.

As Licensify is moving to Java 8 we should probably just purge this package.