### PR TITLE
Remove jenkins_job_support from the Jenkins master

### DIFF
--- a/modules/ci_environment/manifests/jenkins_master.pp
+++ b/modules/ci_environment/manifests/jenkins_master.pp
@@ -45,7 +45,6 @@ class ci_environment::jenkins_master (
     repo => 0,
   }
   include jenkins_user
-  include jenkins_job_support
 
   Class['java'] -> Class['jenkins'] -> Class['jenkins_user']
   Package <| title == 'jenkins' |> -> Jenkins::Plugin <| |>


### PR DESCRIPTION
The Jenkins master doesn't run any Jenkins job so it seems weird that it has the classes that support Jenkins jobs installed on it.