### PR TITLE
Fix ordering issue

### DIFF
--- a/modules/pact_broker/manifests/init.pp
+++ b/modules/pact_broker/manifests/init.pp
@@ -47,6 +47,7 @@ class pact_broker (
 ) {
 
   include nginx
+  include postgresql::server
 
   nginx::resource::vhost { $vhost:
     proxy            => "http://localhost:${port}/",


### PR DESCRIPTION
ci-deployment was failing to run seemingly because of an ordering issue
raised by the pact_broker class, throwing errors like:

```
Warning: Scope(Postgresql::Server::Grant[database:GRANT pact_broker -
ALL - pact_broker]): Could not look up qualified variable
'postgresql::server::psql_path'; class postgresql::server has not been
evaluated
```

Which resulted in Puppet failing to run:

```
Error: Could not find dependency Class[Postgresql::Server::Service] for
Postgresql_psql[Check for existence of db 'pact_broker'] at
/home/lauramartin/puppet/vendor/modules/postgresql/manifests/server/database.pp:58
```

This specifically adds in a prerequisite for the postgresql::server
class which allows Puppet to successfully run on the ci-master.