### PR TITLE
Add golang v1.6.3

### DIFF
--- a/modules/ci_environment/manifests/jenkins_job_support.pp
+++ b/modules/ci_environment/manifests/jenkins_job_support.pp
@@ -49,13 +49,9 @@ class ci_environment::jenkins_job_support {
   }
 
   class { 'goenv':
-    global_version => '1.5.3',
+    global_version => '1.6.3',
   }
-  goenv::version { ['1.3.3', '1.4.2', '1.4.3', '1.5.1', '1.5.3', '1.6.2']: }
-  # FIXME: Remove once cleaned up everywhere.
-  goenv::version { ['1.2.2', '1.3.1', '1.4.1']:
-    ensure => absent,
-  }
+  goenv::version { ['1.3.3', '1.4.2', '1.4.3', '1.5.1', '1.5.3', '1.6.2', '1.6.3']: }
 
   package { ['golang-gom', 'godep']:
     ensure => latest,


### PR DESCRIPTION
Adds the latest golang version for CI. This has been released as a security fix and we are in the process of upgrading apps (primarily router) so require this version on the CI boxes.

cc/ @timblair 