### PR TITLE
CI Slave MongoDB Upgrade

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -8,17 +8,19 @@ mod 'gdsoperations/goenv',         '0.0.4'
 mod 'gdsoperations/openconnect'
 mod 'gdsoperations/rbenv',         '1.2.0'
 mod 'jfryman/nginx',               '0.2.7'
-mod 'puppetlabs/apt',              '~> 1.7'
+mod 'puppetlabs/apt',              '~> 2.2.2'
+mod 'puppet/unattended_upgrades',  '2.0.0' # required now that 'apt::unattended_upgrades' class no longer exists
 mod 'puppetlabs/git',              '0.0.2'
 mod 'puppetlabs/java'
 mod 'puppetlabs/lvm',              '0.3.3'
 mod 'puppetlabs/mysql',            '0.9.0'
 mod 'puppetlabs/nodejs',           '0.4.0'
-mod 'puppetlabs/postgresql'
+mod 'puppetlabs/mongodb',          '0.13.0'
+mod 'puppetlabs/postgresql',       '4.4.0'
 mod 'puppetlabs/rabbitmq',
   :git => 'git://github.com/alphagov/puppetlabs-rabbitmq.git',
   :ref => 'strip-backslashes'
-mod 'puppetlabs/stdlib',           '~> 4.0'
+mod 'puppetlabs/stdlib',           '~> 4.6.0'
 mod 'saz/dnsmasq',                 '1.2.0'
 
 mod 'alphagov/clamav',        :git => 'git://github.com/alphagov/puppet-clamav',
@@ -32,9 +34,7 @@ mod 'gds/graphite',           :git => 'git://github.com/gds-operations/puppet-gr
                               :ref => '45663a5cd8ed72d7cb8d19e535136cacd893689d'
 mod 'alphagov/harden',        :git => 'git://github.com/alphagov/puppet-harden.git',
                               :ref => '5b27ee25e19f0c5421665246b76a13def8058e1c'
-mod 'alphagov/jenkins',       :git => 'git://github.com/alphagov/puppet-jenkins.git',
-                              :ref => 'ca40459bea5a9dc91e12e8014c9878fcd2856ee7'
-mod 'alphagov/mongodb',       :git => 'git://github.com/alphagov/puppetlabs-mongodb.git',
-                              :ref => '1661646b1391c47417d1d25b0a541fdc53bf7729'
 mod 'alphagov/rsyslog',       :git => 'git://github.com/alphagov/puppet-rsyslog.git',
                               :ref => 'acf2755cda80e2ecd107ed8de4d275c383db0487'
+mod 'jenkinsci/puppet-jenkins', :git => 'https://github.com/jenkinsci/puppet-jenkins.git',
+                                :ref => 'v1.7.0'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -7,6 +7,7 @@ FORGE
       puppetlabs-stdlib (>= 2.2.1)
     attachmentgenie-ufw (1.1.0)
       puppetlabs-stdlib (>= 2.2.1)
+    darin-zypprepo (1.0.2)
     elasticsearch-elasticsearch (0.4.0)
       puppetlabs-stdlib (>= 3.2.0)
     gdsoperations-goenv (0.0.4)
@@ -18,27 +19,33 @@ FORGE
       puppetlabs-concat (< 2.0.0, >= 1.1.1)
       puppetlabs-stdlib (< 5.0.0, >= 4.2.0)
     nanliu-staging (0.4.1)
-    puppetlabs-apt (1.8.0)
-      puppetlabs-stdlib (>= 2.2.1)
+    puppet-archive (1.1.1)
+      puppetlabs-stdlib (< 5.0.0, >= 4.2.0)
+    puppet-unattended_upgrades (2.0.0)
+      puppetlabs-apt (< 3.0.0, >= 2.2.0)
+      puppetlabs-stdlib (< 5.0.0, >= 4.6.0)
+    puppetlabs-apt (2.2.2)
+      puppetlabs-stdlib (< 5.0.0, >= 4.5.0)
     puppetlabs-concat (1.2.4)
       puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
-    puppetlabs-firewall (1.1.3)
     puppetlabs-git (0.0.2)
-    puppetlabs-java (1.2.0)
-      puppetlabs-stdlib (>= 2.4.0)
+    puppetlabs-java (1.6.0)
+      puppetlabs-stdlib (< 5.0.0, >= 2.4.0)
     puppetlabs-lvm (0.3.3)
       puppetlabs-stdlib (>= 4.1.0)
+    puppetlabs-mongodb (0.13.0)
+      puppetlabs-apt (< 3.0.0, >= 1.0.0)
+      puppetlabs-stdlib (< 5.0.0, >= 2.2.0)
     puppetlabs-mysql (0.9.0)
       puppetlabs-stdlib (>= 2.2.1)
     puppetlabs-nodejs (0.4.0)
       puppetlabs-apt (>= 0.0.3)
       puppetlabs-stdlib (>= 2.0.0)
-    puppetlabs-postgresql (3.4.1)
-      puppetlabs-apt (< 2.0.0, >= 1.1.0)
-      puppetlabs-concat (< 2.0.0, >= 1.0.0)
-      puppetlabs-firewall (>= 0.0.4)
-      puppetlabs-stdlib (< 5.0.0, >= 3.2.0)
-    puppetlabs-stdlib (4.9.0)
+    puppetlabs-postgresql (4.4.0)
+      puppetlabs-apt (< 3.0.0, >= 1.8.0)
+      puppetlabs-concat (< 2.0.0, >= 1.1.0)
+      puppetlabs-stdlib (~> 4.0)
+    puppetlabs-stdlib (4.6.0)
     saz-dnsmasq (1.2.0)
       puppetlabs-stdlib (>= 2.0.0)
     torrancew-account (0.0.5)
@@ -82,28 +89,11 @@ GIT
     alphagov-harden (0.0.1)
 
 GIT
-  remote: git://github.com/alphagov/puppet-jenkins.git
-  ref: ca40459bea5a9dc91e12e8014c9878fcd2856ee7
-  sha: ca40459bea5a9dc91e12e8014c9878fcd2856ee7
-  specs:
-    alphagov-jenkins (0.2.4)
-      puppetlabs-apt (>= 0.0.3)
-      puppetlabs-stdlib (>= 2.0.0)
-
-GIT
   remote: git://github.com/alphagov/puppet-rsyslog.git
   ref: acf2755cda80e2ecd107ed8de4d275c383db0487
   sha: acf2755cda80e2ecd107ed8de4d275c383db0487
   specs:
     alphagov-rsyslog (2.0.1)
-
-GIT
-  remote: git://github.com/alphagov/puppetlabs-mongodb.git
-  ref: 1661646b1391c47417d1d25b0a541fdc53bf7729
-  sha: 1661646b1391c47417d1d25b0a541fdc53bf7729
-  specs:
-    alphagov-mongodb (0.1.0)
-      puppetlabs-apt (>= 0.0.2)
 
 GIT
   remote: git://github.com/alphagov/puppetlabs-rabbitmq.git
@@ -123,14 +113,24 @@ GIT
     gds-graphite (0.1.0)
       puppetlabs-stdlib (>= 2.5)
 
+GIT
+  remote: https://github.com/jenkinsci/puppet-jenkins.git
+  ref: v1.7.0
+  sha: c1da0b46afae711382bdb1f03f12750f30eeea88
+  specs:
+    jenkinsci-puppet-jenkins (1.7.0)
+      darin-zypprepo (< 2.0.0, >= 1.0.1)
+      puppet-archive (>= 0.4.8)
+      puppetlabs-apt (< 3.0.0, >= 0.0.3)
+      puppetlabs-java (< 2.0.0, >= 1.0.1)
+      puppetlabs-stdlib (< 5.0.0, >= 4.6.0)
+
 DEPENDENCIES
   alphagov-clamav (>= 0)
   alphagov-duplicity (>= 0)
   alphagov-ext4mount (>= 0)
   alphagov-gds_accounts (>= 0)
   alphagov-harden (>= 0)
-  alphagov-jenkins (>= 0)
-  alphagov-mongodb (>= 0)
   alphagov-rsyslog (>= 0)
   attachmentgenie-locales (= 1.0.2)
   attachmentgenie-ssh (= 1.2.1)
@@ -140,15 +140,18 @@ DEPENDENCIES
   gdsoperations-goenv (= 0.0.4)
   gdsoperations-openconnect (>= 0)
   gdsoperations-rbenv (= 1.2.0)
+  jenkinsci-puppet-jenkins (>= 0)
   jfryman-nginx (= 0.2.7)
-  puppetlabs-apt (~> 1.7)
+  puppet-unattended_upgrades (= 2.0.0)
+  puppetlabs-apt (~> 2.2.2)
   puppetlabs-git (= 0.0.2)
   puppetlabs-java (>= 0)
   puppetlabs-lvm (= 0.3.3)
+  puppetlabs-mongodb (= 0.13.0)
   puppetlabs-mysql (= 0.9.0)
   puppetlabs-nodejs (= 0.4.0)
-  puppetlabs-postgresql (>= 0)
+  puppetlabs-postgresql (= 4.4.0)
   puppetlabs-rabbitmq (>= 0)
-  puppetlabs-stdlib (~> 4.0)
+  puppetlabs-stdlib (~> 4.6.0)
   saz-dnsmasq (= 1.2.0)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ def vagrant_config(config, version)
   dist = ENV['gds_ci_dist'] || DIST_PREFERRED
 
   nodes = {
-    'ci-master-1' => {:ip => '172.16.11.10', :memory => 1024},
+    'ci-master-1' => {:ip => '172.16.11.10'},
     'ci-slave-1'  => {:ip => '172.16.11.11'},
     'ci-slave-2'  => {:ip => '172.16.11.12'},
     'ci-slave-3'  => {:ip => '172.16.11.13'},
@@ -38,12 +38,13 @@ def vagrant_config(config, version)
   }
 
   if dist == 'precise'
-    config.vm.box     = "puppetlabs/ubuntu-12.04-64-puppet"
+    config.vm.box          = "ubuntu/precise64"
+    config.vm.box_version  = '20160815.0.0'
   else
-    config.vm.box     = "puppetlabs/ubuntu-14.04-64-puppet"
+    config.vm.box          = "ubuntu/trusty64"
+    config.vm.box_version  = '20160818.0.0'
   end
 
-  config.vm.box_version = '1.0.1'
 
   config.vm.provision :shell, :path => 'tools/bootstrap'
   config.vm.provision :puppet do |puppet|
@@ -80,7 +81,7 @@ def vagrant_config(config, version)
       modifyvm_args = ['modifyvm', :id]
       modifyvm_args << "--name" << fqdn
       if node_opts[:memory]
-        modifyvm_args << "--memory" << node_opts[:memory]
+        modifyvm_args << "--memory" << 1024
       end
       # Isolate guests from host networking.
       modifyvm_args << "--natdnsproxy1" << "on"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,7 +1,7 @@
 ---
 classes:
   - apt
-  - apt::unattended_upgrades
+  - unattended_upgrades # reboot defaults to false
   - ci_environment::base
   - ci_environment::dns
   - ci_environment::unused_kernels
@@ -11,7 +11,6 @@ classes:
 
 apt::always_apt_update: true
 apt::purge_sources_list_d: true
-apt::unattended_upgrades::auto_reboot: false
 
 # Self signed. For transition-logs development.
 cdn_logs::key: |

--- a/hieradata/role.ci-master.yaml
+++ b/hieradata/role.ci-master.yaml
@@ -8,7 +8,7 @@ classes:
 ci_environment::jenkins_user::jenkins_home: /var/lib/jenkins
 ci_environment::jenkins_master::jenkins_home: /var/lib/jenkins
 
-jenkins::version: "1.532.1"
+jenkins::version: "1.554.2"
 jenkins::plugin_hash:
     greenballs:
         version: "1.12"

--- a/hieradata/role.ci-slave.3.yaml
+++ b/hieradata/role.ci-slave.3.yaml
@@ -1,5 +1,24 @@
 ---
+classes:
+ - mongodb::client # In MongoDB 3.x the client is no longer included as part of the server install
+
 ci_environment::jenkins_slave::labels:
   - 'elasticsearch-1.4'
-  - 'mongodb-2.4'
+  - 'mongodb-3.2'
   - 'postgresql-9.3'
+
+apt::sources:
+  'mongodb3.2':
+    location: 'http://repo.mongodb.org/apt/ubuntu/'
+    release: 'trusty/mongodb-org/3.2'
+    architecture: ::architecture
+    repos: 'multiverse'
+    key: '42F3E95A2C4F08279C4960ADD68FA50FEA312927'
+
+mongodb::globals::version: '3.2.9'
+mongodb::globals::manage_package: true
+mongodb::replSet::sets: 'gds-ci-mongodb-3'
+gds_mongodb::replSet: 'gds-ci-mongodb-3'
+gds_mongodb::service: 'mongod'
+
+

--- a/hieradata/role.ci-slave.5.yaml
+++ b/hieradata/role.ci-slave.5.yaml
@@ -1,7 +1,25 @@
 ---
+classes:
+ - mongodb::client # In MongoDB 3.x the client is no longer included as part of the server install
+
 ci_environment::jenkins_slave::labels:
   - 'elasticsearch-0.90'
-  - 'mongodb-2.4'
+  - 'mongodb-3.2'
   - 'postgresql-9.3'
 
 gds_elasticsearch::version: '0.90.12'
+
+apt::sources:
+  'mongodb3.2':
+    location: 'http://repo.mongodb.org/apt/ubuntu/'
+    release: 'trusty/mongodb-org/3.2'
+    architecture: ::architecture
+    repos: 'multiverse'
+    key: '42F3E95A2C4F08279C4960ADD68FA50FEA312927'
+
+mongodb::globals::version: '3.2.9'
+mongodb::globals::manage_package: true
+mongodb::replSet::sets: 'gds-ci-mongodb-3'
+gds_mongodb::replSet: 'gds-ci-mongodb-3'
+gds_mongodb::service: 'mongod'
+

--- a/hieradata/role.ci-slave.yaml
+++ b/hieradata/role.ci-slave.yaml
@@ -6,19 +6,17 @@ classes:
  - mongodb
  - gds_mongodb
 
-apt::unattended_upgrades::auto_reboot: true
 
 ci_environment::jenkins_slave::jenkins_home: /home/jenkins
 
 gds_mongodb::members: ['localhost']
 gds_mongodb::replSet: 'gds-ci'
+gds_mongodb::service: 'mongodb'
 
-jenkins::slave::manage_slave_user: 1
+jenkins::slave::manage_slave_user: true
 jenkins::slave::slave_user: jenkins
 jenkins::slave::slave_home: /home/jenkins
-jenkins::slave::version: 1.9
+jenkins::slave::version: '1.9'
 
-mongodb::replSet: 'gds-ci'
-mongodb::enable_10gen: true
-mongodb::version: 2.4.9
+mongodb::replSet:sets: 'gds-ci'
 mongodb::smallfiles: true

--- a/modules/ci_environment/manifests/api_user.pp
+++ b/modules/ci_environment/manifests/api_user.pp
@@ -1,0 +1,50 @@
+# == Define: ci_environment::api_user
+#
+# Create an account within Jenkins that will subsequently be used for API
+# access. No API token will be set as it needs to be hashed against a seed
+# that it specific to that installation of Jenkins. You will need to
+# subsequently generate a token through the Jenkins UI. The contents of the
+# user config file will not be managed after initial creation to prevent
+# conflicts with the Jenkins UI.
+#
+# The name of the instance ($title) is used as the account name.
+#
+# === Parameters
+#
+# [*ensure*]
+#   Standard ensure param. Can be used to remove an existing user.
+#   Default: present
+#
+# [*users_dir*]
+#   Directory that Jenkins keeps it's user configs. The default should be
+#   fine for installations from the official packages.
+#   Default: /var/lib/jenkins/users
+#
+define ci_environment::api_user(
+  $ensure = present,
+  $users_dir = $::ci_environment::jenkins_master::users_dir
+) {
+  $ensure_directory = $ensure ? {
+    /^present$/ => directory,
+    default     => absent,
+  }
+
+  File {
+    owner  => 'jenkins',
+    mode   => '0640',
+    notify => Class['jenkins::service'],
+  }
+
+  file { "${users_dir}/${title}" :
+    ensure  => $ensure_directory,
+    recurse => true,
+    purge   => true,
+    force   => true,
+  }
+
+  file { "${users_dir}/${title}/config.xml":
+    ensure  => $ensure,
+    content => template('ci_environment/api_user.xml.erb'),
+    replace => false,
+  }
+}

--- a/modules/ci_environment/templates/api_user.xml.erb
+++ b/modules/ci_environment/templates/api_user.xml.erb
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<user>
+  <fullName>api_user: <%= @title -%></fullName>
+  <description>This local user has been created, but not subsequently managed, by Puppet.&#xd;
+Before first use you will need to generate an API token below.&#xd;
+That API token should then be distributed to any clients.</description>
+  <properties>
+    <jenkins.security.ApiTokenProperty>
+      <apiToken>REGENERATE_THIS_USING_THE_JENKINS_UI</apiToken>
+    </jenkins.security.ApiTokenProperty>
+    <com.cloudbees.plugins.credentials.UserCredentialsProvider_-UserCredentialsProperty plugin="credentials@1.3.1">
+      <credentials/>
+    </com.cloudbees.plugins.credentials.UserCredentialsProvider_-UserCredentialsProperty>
+    <hudson.model.MyViewsProperty>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson.model.MyViewsProperty" reference="../../.."/>
+          <name>All</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+          <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+      </views>
+    </hudson.model.MyViewsProperty>
+    <hudson.search.UserSearchProperty>
+      <insensitiveSearch>false</insensitiveSearch>
+    </hudson.search.UserSearchProperty>
+    <hudson.tasks.Mailer_-UserProperty plugin="mailer@1.4"/>
+  </properties>
+</user>

--- a/modules/gds_elasticsearch/manifests/repo.pp
+++ b/modules/gds_elasticsearch/manifests/repo.pp
@@ -16,6 +16,6 @@ class gds_elasticsearch::repo(
     release      => 'stable',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
-    include_src  => false,
+    include      => { 'src' => false },
   }
 }

--- a/modules/gds_elasticsearch/spec/classes/gds_elasticsearch_spec.rb
+++ b/modules/gds_elasticsearch/spec/classes/gds_elasticsearch_spec.rb
@@ -6,6 +6,7 @@ describe 'gds_elasticsearch', :type => :class do
     :lsbdistid => 'ubuntu',
     :operatingsystem => 'Ubuntu',
     :kernel => 'Linux',
+    :osfamily => 'Debian',
   }}
 
   describe '#version' do

--- a/modules/gds_mongodb/manifests/init.pp
+++ b/modules/gds_mongodb/manifests/init.pp
@@ -1,5 +1,22 @@
+# == Class: gds_mongodb
+#
 # class to configure a replica set
-class gds_mongodb($members, $replSet) {
+#
+# === Parameters
+# [*members*]
+#   Individual hosts in a replicaset. Defined as an array.
+#
+# [*replSet*]
+#   Name of the replicaset.
+#
+# [*service*]
+#   MongoDB-Server daemon name.
+#
+class gds_mongodb(
+  $members,
+  $replSet,
+  $service
+) {
   file { '/etc/mongodb':
     ensure => 'directory',
     owner  => 'root',
@@ -21,7 +38,7 @@ class gds_mongodb($members, $replSet) {
     unless  => "/usr/bin/mongo --host ${members[0]} --quiet --eval 'rs.status().ok' | grep -q 1",
     require => [
       File['/etc/mongodb/configure-replica-set.js'],
-      Service['mongodb'],
+      Service[$service],
     ],
   }
 }

--- a/modules/gds_rabbitmq/manifests/repo.pp
+++ b/modules/gds_rabbitmq/manifests/repo.pp
@@ -5,7 +5,8 @@ class gds_rabbitmq::repo {
     release      => 'testing',
     architecture => $::architecture,
     key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
-    include_src  => false,
+    include      => { 'src' => false },
+
   }
 
   Class['gds_rabbitmq::repo'] -> Package<| title == 'rabbitmq-server' |>


### PR DESCRIPTION
What
We recently provisioned a MongoDB cluster running version 3.x as part of the Licensing upgrade.
To keep tests consistent we have to ensure they're performed in a like environment.
Now that we have a mixed versioned environment we only need to provision some machines with the upgrade.

Current version of MongoDB:
2.4.9.

How
Upgrade vendor module "https://forge.puppet.com/puppetlabs/mongodb" to v0.13.0 to ensure dependency compatibility with other modules.
Purge MongoDB v2.x from two 'ci-slave' instances.
Install MongoDB v3.x on two 'ci-slave' instances.
Apply generic config to 'ci-saves' running MongoDB v3.x.

Use upgraded vendor modules instead of alphagov forks.
and
Upgrade any existing modules as a result of upgrading MongoDB to maintain dependency harmony:
puppetlabs/apt           = 2.2.2
puppetlabs/mongodb       = 0.13.0
puppetlabs/postgresql    = 4.4.0
puppetlabs/stdlib        = 4.6.0
jenkinsci/puppet-jenkins = 1.7.0

Vagrant and Virtualbox:

- Modified vagrant to Ubuntu's box.
- Increased memory allocation to 1GB. Any less prevents the VM from being fully provisioned.

Removed deprecated features as a result of upgrading vendor modules.