### PR TITLE
Move apt from hieradata to base

### DIFF
--- a/hieradata/env.development.yaml
+++ b/hieradata/env.development.yaml
@@ -8,12 +8,6 @@ apt::sources:
     repos: 'main dependencies'
     key: '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30'
 
-  'rbenv-ruby':
-    location: 'http://apt.production.alphagov.co.uk/rbenv-ruby'
-    release: $::lsbdistcodename
-    architecture: $::architecture
-    key: '3803E444EB0235822AA36A66EC5FE1A937E3ACBB'
-
 ci_environment::jenkins_job_support::postgresql::mapit_role_password: 'mapit'
 
 ci_environment::jenkins_master::vhost: 'ci.example.com'

--- a/modules/ci_environment/manifests/base.pp
+++ b/modules/ci_environment/manifests/base.pp
@@ -5,6 +5,14 @@
 class ci_environment::base {
   apt::ppa { 'ppa:gds/govuk': }
 
+  apt::source { 'govuk-rbenv':
+    location     => 'http://apt.production.alphagov.co.uk/rbenv-ruby',
+    release      => $::lsbdistcodename,
+    architecture => $::architecture,
+    key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+    include_src  => false,
+  }
+
   if $::lsbdistcodename != 'trusty' {
     apt::ppa { 'ppa:gds/ci': }
   }


### PR DESCRIPTION
When trying to deploy #432 the apt package was not found.

cc @deanwilson 