### PR TITLE
Fix breaking spec tests

### DIFF
--- a/modules/gds_elasticsearch/spec/classes/gds_elasticsearch_spec.rb
+++ b/modules/gds_elasticsearch/spec/classes/gds_elasticsearch_spec.rb
@@ -6,6 +6,7 @@ describe 'gds_elasticsearch', :type => :class do
     :lsbdistid => 'ubuntu',
     :operatingsystem => 'Ubuntu',
     :kernel => 'Linux',
+    :osfamily => 'Debian',
   }}
 
   describe '#version' do


### PR DESCRIPTION
These were never runnable on OSX. Adding osfamily to specs means you can test on a mac.