### PR TITLE
Upgrade mongo

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -11,6 +11,7 @@ mod 'puppetlabs/apt',              '~> 1.7'
 mod 'puppetlabs/git',              '0.0.2'
 mod 'puppetlabs/java'
 mod 'puppetlabs/lvm',              '0.3.3'
+mod 'puppetlabs/mongodb',          '0.13.0'
 mod 'puppetlabs/mysql',            '0.9.0'
 mod 'puppetlabs/nodejs',           '0.4.0'
 mod 'puppetlabs/postgresql'
@@ -33,8 +34,6 @@ mod 'alphagov/harden',        :git => 'git://github.com/alphagov/puppet-harden.g
                               :ref => '5b27ee25e19f0c5421665246b76a13def8058e1c'
 mod 'alphagov/jenkins',       :git => 'git://github.com/alphagov/puppet-jenkins.git',
                               :ref => '14670f22c7dd2892d82e1fada5a66ed24bb36fa3'
-mod 'alphagov/mongodb',       :git => 'git://github.com/alphagov/puppetlabs-mongodb.git',
-                              :ref => '1661646b1391c47417d1d25b0a541fdc53bf7729'
 mod 'alphagov/rsyslog',       :git => 'git://github.com/alphagov/puppet-rsyslog.git',
                               :ref => 'acf2755cda80e2ecd107ed8de4d275c383db0487'
 mod 'attachmentgenie/locales', :git => 'git://github.com/attachmentgenie/attachmentgenie-locales.git',

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -26,6 +26,9 @@ FORGE
       puppetlabs-stdlib (>= 2.4.0)
     puppetlabs-lvm (0.3.3)
       puppetlabs-stdlib (>= 4.1.0)
+    puppetlabs-mongodb (0.13.0)
+      puppetlabs-apt (< 3.0.0, >= 1.0.0)
+      puppetlabs-stdlib (< 5.0.0, >= 2.2.0)
     puppetlabs-mysql (0.9.0)
       puppetlabs-stdlib (>= 2.2.1)
     puppetlabs-nodejs (0.4.0)
@@ -96,14 +99,6 @@ GIT
     alphagov-rsyslog (2.0.1)
 
 GIT
-  remote: git://github.com/alphagov/puppetlabs-mongodb.git
-  ref: 1661646b1391c47417d1d25b0a541fdc53bf7729
-  sha: 1661646b1391c47417d1d25b0a541fdc53bf7729
-  specs:
-    alphagov-mongodb (0.1.0)
-      puppetlabs-apt (>= 0.0.2)
-
-GIT
   remote: git://github.com/alphagov/puppetlabs-rabbitmq.git
   ref: strip-backslashes
   sha: a6a98e4ab722a01ca47a39ca371eccbcfa4888b6
@@ -136,7 +131,6 @@ DEPENDENCIES
   alphagov-gds_accounts (>= 0)
   alphagov-harden (>= 0)
   alphagov-jenkins (>= 0)
-  alphagov-mongodb (>= 0)
   alphagov-rsyslog (>= 0)
   attachmentgenie-locales (>= 0)
   attachmentgenie-ssh (= 1.2.1)
@@ -151,6 +145,7 @@ DEPENDENCIES
   puppetlabs-git (= 0.0.2)
   puppetlabs-java (>= 0)
   puppetlabs-lvm (= 0.3.3)
+  puppetlabs-mongodb (= 0.13.0)
   puppetlabs-mysql (= 0.9.0)
   puppetlabs-nodejs (= 0.4.0)
   puppetlabs-postgresql (>= 0)

--- a/hieradata/role.ci-slave.3.yaml
+++ b/hieradata/role.ci-slave.3.yaml
@@ -1,5 +1,13 @@
 ---
 ci_environment::jenkins_slave::labels:
   - 'elasticsearch-1.4'
-  - 'mongodb-2.4'
+  - 'mongodb-3.2'
   - 'postgresql-9.3'
+
+
+gds_mongodb::enable_mongo3_repo: true
+mongodb::globals::version: 3.2.7
+mongodb::globals::server_package_name: mongodb-org-server
+mongodb::globals::manage_package: true
+mongodb::replset::sets: 'gds-ci-mongodb-3'
+gds_mongodb::replSet: 'gds-ci-mongodb-3'

--- a/hieradata/role.ci-slave.5.yaml
+++ b/hieradata/role.ci-slave.5.yaml
@@ -1,7 +1,14 @@
 ---
 ci_environment::jenkins_slave::labels:
   - 'elasticsearch-0.90'
-  - 'mongodb-2.4'
+  - 'mongodb-3.2'
   - 'postgresql-9.3'
 
 gds_elasticsearch::version: '0.90.12'
+
+gds_mongodb::enable_mongo3_repo: true
+mongodb::globals::version: 3.2.7
+mongodb::globals::server_package_name: mongodb-org-server
+mongodb::globals::manage_package: true
+mongodb::replset::sets: 'gds-ci-mongodb-3'
+gds_mongodb::replSet: 'gds-ci-mongodb-3'

--- a/hieradata/role.ci-slave.yaml
+++ b/hieradata/role.ci-slave.yaml
@@ -18,7 +18,7 @@ jenkins::slave::slave_user: jenkins
 jenkins::slave::slave_home: /home/jenkins
 jenkins::slave::version: 1.9
 
-mongodb::replSet: 'gds-ci'
-mongodb::enable_10gen: true
-mongodb::version: 2.4.9
+mongodb::replset::sets: 'gds-ci'
+mongodb::globals::version: 2.4.9
+mongodb::globals::server_package_name: mongodb-10gen
 mongodb::smallfiles: true

--- a/modules/gds_mongodb/manifests/init.pp
+++ b/modules/gds_mongodb/manifests/init.pp
@@ -1,10 +1,18 @@
 # class to configure a replica set
-class gds_mongodb($members, $replSet) {
+class gds_mongodb($members, $replSet, $enable_mongo3_repo = false) {
+
   file { '/etc/mongodb':
     ensure => 'directory',
     owner  => 'root',
     group  => 'root',
     mode   => '0644',
+  }
+
+  if $enable_mongo3_repo {
+    include ::gds_mongodb::repo::mongodb3
+    include ::mongodb::client             # In MongoDB 3.x the client is no longer included as part of the server install
+  } else {
+    include ::gds_mongodb::repo::mongodb2
   }
 
   file { '/etc/mongodb/configure-replica-set.js':

--- a/modules/gds_mongodb/manifests/repo/mongodb2.pp
+++ b/modules/gds_mongodb/manifests/repo/mongodb2.pp
@@ -1,0 +1,16 @@
+# Add the packagree repo for mongodb 2 packages
+class gds_mongodb::repo::mongodb2 {
+
+  if $::lsbdistcodename == 'trusty' {
+    apt::source { '10gen':
+      location    => 'http://downloads-distro.mongodb.org/repo/ubuntu-upstart',
+      release     => 'dist',
+      repos       => '10gen',
+      key         => '492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10',
+      key_server  => 'hkp://keyserver.ubuntu.com:80',
+      include_src => false,
+      before      => Class['mongodb'],
+    }
+  }
+
+}

--- a/modules/gds_mongodb/manifests/repo/mongodb3.pp
+++ b/modules/gds_mongodb/manifests/repo/mongodb3.pp
@@ -1,0 +1,16 @@
+# Add the packagree repo for mongodb 3 packages
+class gds_mongodb::repo::mongodb3 {
+
+  if $::lsbdistcodename == 'trusty' {
+    apt::source { 'mongodb3.2':
+      location     => 'http://apt.publishing.service.gov.uk/mongodb3.2',
+      release      => 'trusty-mongodb-org-3.2',
+      repos        => 'multiverse',
+      architecture => $::architecture,
+      key          => '3803E444EB0235822AA36A66EC5FE1A937E3ACBB',
+      before       => Class['mongodb'],
+      include_src  => false,
+    }
+  }
+
+}


### PR DESCRIPTION
We currently have a custom fork of the MongoDB module that we no longer want
to maintain. Moving back to upstream puts us back on the support path
and provides support for the MongoDB 3.

Gated package repository for MongoDB 3.

We have to define package repositories manually due to a bug
in the upstream puppetlabs/mongodb module. https://tickets.puppetlabs.com/browse/MODULES-2532