### PR TITLE
Install MongoDB Tools

### DIFF
--- a/modules/gds_mongodb/manifests/init.pp
+++ b/modules/gds_mongodb/manifests/init.pp
@@ -32,4 +32,9 @@ class gds_mongodb($members, $replSet, $enable_mongo3_repo = false) {
       Service['mongodb'],
     ],
   }
+
+  package { 'mongodb-org-tools':
+    ensure  => present,
+    require => Class['::gds_mongodb::repo::mongodb3'],
+  }
 }


### PR DESCRIPTION
The MongoDB 3 instances do not have mongodb tools installed by default.
The MongoDB tools include things like mongodump, mongorestore...etc

This relates to https://github.com/alphagov/ci-puppet/pull/442