### PR TITLE
Fix PID file path for MongoDB

### DIFF
--- a/hieradata/role.ci-slave.3.yaml
+++ b/hieradata/role.ci-slave.3.yaml
@@ -10,4 +10,5 @@ mongodb::globals::version: 3.2.7
 mongodb::globals::server_package_name: mongodb-org-server
 mongodb::globals::manage_package: true
 mongodb::replset::sets: 'gds-ci-mongodb-3'
+mongodb::server::pidfilepath: '/var/run/mongodb.pid'
 gds_mongodb::replSet: 'gds-ci-mongodb-3'

--- a/hieradata/role.ci-slave.5.yaml
+++ b/hieradata/role.ci-slave.5.yaml
@@ -11,4 +11,5 @@ mongodb::globals::version: 3.2.7
 mongodb::globals::server_package_name: mongodb-org-server
 mongodb::globals::manage_package: true
 mongodb::replset::sets: 'gds-ci-mongodb-3'
+mongodb::server::pidfilepath: '/var/run/mongodb.pid'
 gds_mongodb::replSet: 'gds-ci-mongodb-3'

--- a/hieradata/role.ci-slave.d34n1.yaml
+++ b/hieradata/role.ci-slave.d34n1.yaml
@@ -11,4 +11,5 @@ mongodb::globals::version: 3.2.7
 mongodb::globals::server_package_name: mongodb-org-server
 mongodb::globals::manage_package: true
 mongodb::replset::sets: 'gds-ci-mongodb-3'
+mongodb::server::pidfilepath: '/var/run/mongodb.pid'
 gds_mongodb::replSet: 'gds-ci-mongodb-3'


### PR DESCRIPTION
The init script that we have for MongoDB 3 expects the pidfile to be at `/var/run/mongodb.pid`:

```
touch /var/run/mongodb.pid
chown $DAEMONUSER /var/run/mongodb.pid
```

Mongo fails to start if the pidfile isn't set correctly.