### PR TITLE
Add slack plugin to Jenkins

### DIFF
--- a/hieradata/role.ci-master.yaml
+++ b/hieradata/role.ci-master.yaml
@@ -86,3 +86,5 @@ jenkins::plugin_hash:
         version: "0.19"
     rebuild:
         version: "1.22"
+    slack:
+        vrsion: "1.7"


### PR DESCRIPTION
We would like to receive some notifications on slack regarding some builds. For
example, when the "Copy Data to <environment>" builds fail, we would like to
have visibility on it. 

The Jenkins' slack plugin will allow us to do this and it is more configurable than using a simple webhook.

More details here: https://wiki.jenkins-ci.org/display/JENKINS/Slack+Plugin

**Note**: The latest version of the slack plugin is `2.0.1`, which needs core to be `1.609.2`. Currently our jenkins version is [1.532.1](https://github.com/alphagov/ci-puppet/blob/4cc64f953d601aea6483d92ce101960014f4ee9a/hieradata/role.ci-master.yaml#L11), therefore I had to use slack version `1.7` to make sure it's compatible.