### PR TITLE
Fix typo on jenkins' plugin list

### DIFF
--- a/hieradata/role.ci-master.yaml
+++ b/hieradata/role.ci-master.yaml
@@ -87,4 +87,4 @@ jenkins::plugin_hash:
     rebuild:
         version: "1.22"
     slack:
-        vrsion: "1.7"
+        version: "1.7"


### PR DESCRIPTION
This was causing the following error:

```
out: Error: Invalid parameter vrsion on Jenkins::Plugin[slack] on node ci-master-1.internal
```