### PR TITLE
Fix hieradata for MongoDB replica sets

### DIFF
--- a/hieradata/role.ci-slave.3.yaml
+++ b/hieradata/role.ci-slave.3.yaml
@@ -9,6 +9,6 @@ gds_mongodb::enable_mongo3_repo: true
 mongodb::globals::version: 3.2.7
 mongodb::globals::server_package_name: mongodb-org-server
 mongodb::globals::manage_package: true
-mongodb::replset::sets: 'gds-ci-mongodb-3'
 mongodb::server::pidfilepath: '/var/run/mongodb.pid'
+mongodb::server::replset: 'gds-ci-mongodb-3'
 gds_mongodb::replSet: 'gds-ci-mongodb-3'

--- a/hieradata/role.ci-slave.5.yaml
+++ b/hieradata/role.ci-slave.5.yaml
@@ -10,6 +10,6 @@ gds_mongodb::enable_mongo3_repo: true
 mongodb::globals::version: 3.2.7
 mongodb::globals::server_package_name: mongodb-org-server
 mongodb::globals::manage_package: true
-mongodb::replset::sets: 'gds-ci-mongodb-3'
 mongodb::server::pidfilepath: '/var/run/mongodb.pid'
+mongodb::server::replset: 'gds-ci-mongodb-3'
 gds_mongodb::replSet: 'gds-ci-mongodb-3'

--- a/hieradata/role.ci-slave.d34n1.yaml
+++ b/hieradata/role.ci-slave.d34n1.yaml
@@ -10,6 +10,6 @@ gds_mongodb::enable_mongo3_repo: true
 mongodb::globals::version: 3.2.7
 mongodb::globals::server_package_name: mongodb-org-server
 mongodb::globals::manage_package: true
-mongodb::replset::sets: 'gds-ci-mongodb-3'
 mongodb::server::pidfilepath: '/var/run/mongodb.pid'
+mongodb::server::replset: 'gds-ci-mongodb-3'
 gds_mongodb::replSet: 'gds-ci-mongodb-3'

--- a/hieradata/role.ci-slave.yaml
+++ b/hieradata/role.ci-slave.yaml
@@ -18,7 +18,7 @@ jenkins::slave::slave_user: jenkins
 jenkins::slave::slave_home: /home/jenkins
 jenkins::slave::version: 1.9
 
-mongodb::replset::sets: 'gds-ci'
 mongodb::globals::version: 2.4.9
 mongodb::globals::server_package_name: mongodb-10gen
+mongodb::server::replset: 'gds-ci'
 mongodb::smallfiles: true


### PR DESCRIPTION
We're using the wrong hieradata key to set the replica set in the MongoDB config file. The correct value is an option to `mongodb::server`.