### PR TITLE
Change the transition-logs-1 git user to specify an actual email address

### DIFF
--- a/modules/ci_environment/files/logs_processor-dot-gitconfig
+++ b/modules/ci_environment/files/logs_processor-dot-gitconfig
@@ -1,3 +1,3 @@
 [user]
-    email = logs.processor@transition-logs-1
+    email = govuk-ci@users.noreply.github.com
     name = Logs Processor


### PR DESCRIPTION
- A while back, we set the transition-logs-1 machine Logs Processor user
  up with a dummy email address, which got
  added to someone's GitHub account so it wasn't completely anonymous.
- We're tidying up, so we're changing this to an email address that
  still won't go anywhere - it being a GitHub one - but makes it more
  obvious which account it's from and what it's used by.

(cc @alexmuller)